### PR TITLE
Add authenticated settings page and update navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Share from './pages/Share.jsx';
 import Home from './pages/Home.jsx';
 import LoginPage from './pages/LoginPage.jsx';
 import SignupPage from './pages/SignupPage.jsx';
+import Settings from './pages/Settings.jsx';
 import { useAuth } from './hooks/useAuth.js';
 import { getPurchasingPowerRatio } from './Econ.js';
 
@@ -66,6 +67,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <Share />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings"
+            element={
+              <ProtectedRoute>
+                <Settings />
               </ProtectedRoute>
             }
           />

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -3,13 +3,13 @@ import { NavLink, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button.jsx';
 import { useAuth } from '../../hooks/useAuth.js';
 import { UserCircleIcon } from '@heroicons/react/24/outline'; // account icon
-import UserAccountMenu from '../../../components/user-account-menu.js';
 
 const authenticatedLinks = [
   { to: '/dashboard', label: 'Dashboard' },
   { to: '/planner', label: 'GeoBudget' },
   { to: '/insights', label: 'Smart-Spend' },
-  { to: '/share', label: 'Share' }
+  { to: '/share', label: 'Share' },
+  { to: '/settings', label: 'Settings' }
 ];
 
 const linkClasses =
@@ -77,7 +77,7 @@ export function NavBar() {
           {user ? (
             <>
               <NavLink
-                to="UserAccountMenu"
+                to="/settings"
                 className="flex items-center gap-2 text-sm font-semibold text-navy/70 hover:text-navy"
               >
                 <UserCircleIcon className="h-5 w-5 text-navy/70" />

--- a/src/components/settings/SettingsSection.jsx
+++ b/src/components/settings/SettingsSection.jsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx';
+import { Card, CardHeader, CardTitle, CardContent } from '../ui/Card.jsx';
+
+export function SettingsSection({
+  title,
+  description,
+  actions,
+  children,
+  footer,
+  className,
+  contentClassName
+}) {
+  return (
+    <Card as="section" className={className}>
+      <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <CardTitle>{title}</CardTitle>
+          {description ? (
+            <p className="max-w-prose text-sm text-slate/70">{description}</p>
+          ) : null}
+        </div>
+        {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+      </CardHeader>
+      <CardContent className={clsx('text-sm text-slate/80', contentClassName)}>{children}</CardContent>
+      {footer ? (
+        <div className="mt-4 border-t border-white/60 pt-4 text-xs text-slate/60">{footer}</div>
+      ) : null}
+    </Card>
+  );
+}
+
+export default SettingsSection;

--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase.js';
+
+function normaliseNumber(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function normaliseCity(city) {
+  if (!city) {
+    return null;
+  }
+
+  return {
+    code: city.code ?? null,
+    name: city.name ?? null,
+    flag: city.flag ?? null,
+    ppp: normaliseNumber(city.ppp)
+  };
+}
+
+function normaliseCountry(country) {
+  if (!country) {
+    return null;
+  }
+
+  return {
+    code: country.code ?? null,
+    name: country.country ?? country.name ?? null
+  };
+}
+
+function mapProfile(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    name: row.name?.trim() || null,
+    monthlyBudget: normaliseNumber(row.monthly_budget),
+    currentCity: normaliseCity(row.current_city),
+    homeCity: normaliseCity(row.home_city),
+    currentCountry: normaliseCountry(row.current_country),
+    homeCountry: normaliseCountry(row.home_country)
+  };
+}
+
+export function useUserProfile(userId) {
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const loadProfile = useCallback(async () => {
+    if (!userId) {
+      return null;
+    }
+
+    const { data, error } = await supabase
+      .from('user_profile')
+      .select(
+        `
+        name,
+        monthly_budget,
+        current_city:ppp_city!user_profile_current_city_code_fkey(code, name, flag, ppp),
+        home_city:ppp_city!user_profile_home_city_code_fkey(code, name, flag, ppp),
+        current_country:country_ref!user_profile_current_country_fkey(code, country),
+        home_country:country_ref!user_profile_home_country_fkey(code, country)
+      `
+      )
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapProfile(data);
+  }, [userId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!userId) {
+      setProfile(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    loadProfile()
+      .then((result) => {
+        if (!cancelled) {
+          setProfile(result);
+        }
+      })
+      .catch((cause) => {
+        if (cancelled) return;
+        const normalisedError =
+          cause instanceof Error ? cause : new Error(typeof cause === 'string' ? cause : 'Failed to load profile');
+        setError(normalisedError);
+        setProfile(null);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, loadProfile]);
+
+  const refresh = useCallback(async () => {
+    if (!userId) {
+      setProfile(null);
+      setError(null);
+      return null;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const result = await loadProfile();
+      setProfile(result);
+      return result;
+    } catch (cause) {
+      const normalisedError =
+        cause instanceof Error ? cause : new Error(typeof cause === 'string' ? cause : 'Failed to refresh profile');
+      setError(normalisedError);
+      setProfile(null);
+      throw normalisedError;
+    } finally {
+      setLoading(false);
+    }
+  }, [loadProfile, userId]);
+
+  return { profile, loading, error, refresh };
+}
+
+export default useUserProfile;

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,0 +1,288 @@
+import { useEffect, useMemo, useState } from 'react';
+import Button from '../components/ui/Button.jsx';
+import { SettingsSection } from '../components/settings/SettingsSection.jsx';
+import { useAuth } from '../hooks/useAuth.js';
+import { useUserProfile } from '../hooks/useUserProfile.js';
+import { supabase } from '../lib/supabase.js';
+
+function formatCurrency(amount, currency = 'USD') {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2
+    }).format(amount);
+  } catch (error) {
+    return `$${Number(amount ?? 0).toFixed(2)}`;
+  }
+}
+
+export default function Settings() {
+  const { user, nessie, isSyncingNessie, refreshNessie } = useAuth();
+  const userId = user?.id ?? null;
+  const {
+    profile,
+    loading: profileLoading,
+    error: profileError,
+    refresh: refreshProfile
+  } = useUserProfile(userId);
+
+  const [displayName, setDisplayName] = useState('');
+  const [monthlyBudget, setMonthlyBudget] = useState('');
+  const [profileStatus, setProfileStatus] = useState(null);
+  const [accountsStatus, setAccountsStatus] = useState(null);
+  const [savingProfile, setSavingProfile] = useState(false);
+
+  const identityFallback = useMemo(() => {
+    if (!user) {
+      return '';
+    }
+
+    const metadataName = user.user_metadata?.displayName;
+    if (metadataName && metadataName.trim()) {
+      return metadataName.trim();
+    }
+
+    if (user.email) {
+      const [local] = user.email.split('@');
+      return local ?? '';
+    }
+
+    return '';
+  }, [user]);
+
+  useEffect(() => {
+    if (profileLoading) {
+      return;
+    }
+
+    setDisplayName(profile?.name ?? identityFallback);
+    setMonthlyBudget(
+      profile?.monthlyBudget != null && !Number.isNaN(profile.monthlyBudget)
+        ? String(profile.monthlyBudget)
+        : ''
+    );
+  }, [profile, profileLoading, identityFallback]);
+
+  const totalBalance = useMemo(() => {
+    if (!Array.isArray(nessie?.accounts)) {
+      return 0;
+    }
+
+    return nessie.accounts.reduce((sum, account) => {
+      return sum + (typeof account.balance === 'number' ? account.balance : 0);
+    }, 0);
+  }, [nessie]);
+
+  const headlineCurrency = nessie?.accounts?.[0]?.currencyCode ?? 'USD';
+
+  async function handleSaveProfile(event) {
+    event.preventDefault();
+    if (!userId) {
+      return;
+    }
+
+    const trimmedName = displayName.trim();
+    const normalisedBudget = monthlyBudget.trim();
+    const parsedBudget = normalisedBudget === '' ? null : Number(normalisedBudget);
+
+    if (parsedBudget != null && Number.isNaN(parsedBudget)) {
+      setProfileStatus({ type: 'error', message: 'Monthly budget must be a valid number.' });
+      return;
+    }
+
+    setSavingProfile(true);
+    setProfileStatus(null);
+
+    try {
+      const updates = {
+        user_id: userId,
+        name: trimmedName || null,
+        monthly_budget: parsedBudget
+      };
+
+      const { error } = await supabase.from('user_profile').upsert(updates, { onConflict: 'user_id' });
+      if (error) {
+        throw error;
+      }
+
+      if (trimmedName) {
+        const { error: metadataError } = await supabase.auth.updateUser({
+          data: {
+            ...(user?.user_metadata ?? {}),
+            displayName: trimmedName
+          }
+        });
+
+        if (metadataError) {
+          throw metadataError;
+        }
+      }
+
+      await refreshProfile();
+      setProfileStatus({ type: 'success', message: 'Profile settings updated successfully.' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update profile settings.';
+      setProfileStatus({ type: 'error', message });
+    } finally {
+      setSavingProfile(false);
+    }
+  }
+
+  async function handleRefreshAccounts() {
+    if (typeof refreshNessie !== 'function') {
+      return;
+    }
+
+    setAccountsStatus(null);
+    try {
+      await refreshNessie();
+      setAccountsStatus({ type: 'success', message: 'Account balances refreshed.' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to refresh accounts right now.';
+      setAccountsStatus({ type: 'error', message });
+    }
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-6 py-12">
+      <header className="mb-10 space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-red/80">Account</p>
+        <h1 className="text-4xl font-bold tracking-tight text-navy">Settings</h1>
+        <p className="max-w-2xl text-base text-slate/80">
+          Update your personal details, budgeting preferences, and refresh your linked Capital One data.
+        </p>
+      </header>
+
+      <div className="space-y-6">
+        {profileStatus ? (
+          <div
+            className={
+              profileStatus.type === 'error'
+                ? 'rounded-2xl border border-red/40 bg-red/5 px-4 py-3 text-sm text-red'
+                : 'rounded-2xl border border-emerald-400/40 bg-emerald-50/80 px-4 py-3 text-sm text-emerald-700'
+            }
+          >
+            {profileStatus.message}
+          </div>
+        ) : null}
+
+        {profileError ? (
+          <div className="rounded-2xl border border-red/40 bg-red/5 px-4 py-3 text-sm text-red">
+            {profileError.message || 'We were unable to load your profile information.'}
+          </div>
+        ) : null}
+
+        <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+          <SettingsSection
+            title="Profile"
+            description="Control how your name appears across PPP Pocket and track your monthly travel savings target."
+            actions={
+              <Button type="submit" form="profile-form" className="px-5 py-2 text-sm" disabled={savingProfile}>
+                {savingProfile ? 'Saving…' : 'Save changes'}
+              </Button>
+            }
+          >
+            <form id="profile-form" onSubmit={handleSaveProfile} className="grid gap-6">
+              <div className="grid gap-2">
+                <label htmlFor="display-name" className="text-xs font-semibold uppercase tracking-[0.2em] text-slate/60">
+                  Display name
+                </label>
+                <input
+                  id="display-name"
+                  type="text"
+                  value={displayName}
+                  onChange={(event) => setDisplayName(event.target.value)}
+                  placeholder="How should we greet you?"
+                  className="w-full rounded-2xl border border-slate/20 bg-white/80 px-4 py-3 text-sm text-navy shadow-inner shadow-white/40 transition focus:border-red focus:outline-none focus:ring-2 focus:ring-red/20"
+                  disabled={savingProfile}
+                />
+                <p className="text-xs text-slate/60">
+                  This name appears on your dashboard and shared parity summaries.
+                </p>
+              </div>
+
+              <div className="grid gap-2">
+                <label htmlFor="monthly-budget" className="text-xs font-semibold uppercase tracking-[0.2em] text-slate/60">
+                  Monthly travel budget (USD)
+                </label>
+                <input
+                  id="monthly-budget"
+                  type="number"
+                  min="0"
+                  step="50"
+                  value={monthlyBudget}
+                  onChange={(event) => setMonthlyBudget(event.target.value)}
+                  placeholder="e.g. 2500"
+                  className="w-full rounded-2xl border border-slate/20 bg-white/80 px-4 py-3 text-sm text-navy shadow-inner shadow-white/40 transition focus:border-red focus:outline-none focus:ring-2 focus:ring-red/20"
+                  disabled={savingProfile}
+                />
+                <p className="text-xs text-slate/60">
+                  We use this number to calculate how long you can stay in each destination.
+                </p>
+              </div>
+            </form>
+          </SettingsSection>
+
+          <SettingsSection
+            title="Capital One sync"
+            description="See the latest balances pulled from your demo Capital One account and refresh whenever you need."
+            actions={
+              <Button
+                type="button"
+                variant="secondary"
+                className="px-4 py-2 text-sm"
+                onClick={handleRefreshAccounts}
+                disabled={isSyncingNessie}
+              >
+                {isSyncingNessie ? 'Refreshing…' : 'Refresh balances'}
+              </Button>
+            }
+            footer="Balances are simulated for the hackathon environment and reset frequently."
+            contentClassName="space-y-4"
+          >
+            <div className="rounded-2xl border border-white/60 bg-gradient-to-br from-white/80 to-white/30 px-4 py-3 shadow-inner">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate/60">Total balance</p>
+              <p className="mt-2 text-2xl font-semibold text-navy">
+                {formatCurrency(totalBalance, headlineCurrency)}
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              {Array.isArray(nessie?.accounts) && nessie.accounts.length > 0 ? (
+                nessie.accounts.map((account) => (
+                  <div
+                    key={account.id}
+                    className="flex items-center justify-between rounded-2xl border border-slate/15 bg-white/70 px-4 py-3 shadow-sm shadow-white/60"
+                  >
+                    <div>
+                      <p className="text-sm font-semibold text-navy">{account.name ?? 'Account'}</p>
+                      <p className="text-xs text-slate/60">•••• {account.mask ?? '0000'}</p>
+                    </div>
+                    <p className="text-sm font-semibold text-slate/80">
+                      {formatCurrency(account.balance ?? 0, account.currencyCode ?? 'USD')}
+                    </p>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-slate/60">Connect an account to see balances here.</p>
+              )}
+            </div>
+
+            {accountsStatus ? (
+              <div
+                className={
+                  accountsStatus.type === 'error'
+                    ? 'rounded-2xl border border-red/40 bg-red/5 px-3 py-2 text-xs text-red'
+                    : 'rounded-2xl border border-emerald-400/40 bg-emerald-50/80 px-3 py-2 text-xs text-emerald-700'
+                }
+              >
+                {accountsStatus.message}
+              </div>
+            ) : null}
+          </SettingsSection>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated settings route for authenticated users with profile editing and account refresh controls
- introduce reusable settings section layout and a hook for loading user profile data
- update the navigation to include the settings destination and link the account chip to it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d808b30230832d95c90c18bb1d212f