### PR TITLE
Improve Nessie fallbacks for auth flow

### DIFF
--- a/components/providers/auth-provider.tsx
+++ b/components/providers/auth-provider.tsx
@@ -11,7 +11,13 @@ import {
 } from 'react'
 import type { Session, User } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase/client'
-import { ensureNessieCustomer, fetchNessieOverview, type NessieAccount, type NessieTransaction } from '@/lib/nessie'
+import {
+  ensureNessieCustomer,
+  fetchNessieOverview,
+  getFallbackNessieOverview,
+  type NessieAccount,
+  type NessieTransaction,
+} from '@/lib/nessie'
 import { fetchUserProfileName, upsertUserProfileName, upsertUserRow } from '@/lib/user-identity'
 
 interface NessieState {
@@ -138,7 +144,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         })
       } catch (error) {
         console.error('Failed to synchronise Nessie data', error)
-        setNessie(initialNessieState)
+        const fallback = getFallbackNessieOverview()
+        setNessie({
+          customerId: fallback.customerId,
+          accounts: normaliseAccounts(fallback.accounts),
+          transactions: normaliseTransactions(fallback.transactions),
+        })
       } finally {
         setSyncingNessie(false)
       }

--- a/data/mock-nessie.ts
+++ b/data/mock-nessie.ts
@@ -1,0 +1,58 @@
+export const DEMO_NESSIE_CUSTOMER_ID = 'demo-customer';
+
+const demoAccounts = [
+  {
+    _id: 'demo-account',
+    nickname: 'Demo Account',
+    balanceUSD: 4250.75,
+    currency: 'USD',
+    type: 'checking',
+    account_number_masked: '0000',
+  },
+] as const;
+
+const demoTransactions = [
+  {
+    _id: 'txn-001',
+    transaction_date: '2024-05-12',
+    payee: 'Publix',
+    category: ['Groceries'],
+    amount: -74.23,
+  },
+  {
+    _id: 'txn-002',
+    transaction_date: '2024-05-10',
+    payee: 'MARTA',
+    category: ['Transport'],
+    amount: -32,
+  },
+  {
+    _id: 'txn-003',
+    transaction_date: '2024-05-01',
+    payee: 'Midtown Loft',
+    category: ['Rent'],
+    amount: -1450,
+  },
+  {
+    _id: 'txn-004',
+    transaction_date: '2024-04-28',
+    payee: 'Blue Bottle Coffee',
+    category: ['Dining'],
+    amount: -8.75,
+  },
+  {
+    _id: 'txn-005',
+    transaction_date: '2024-04-25',
+    payee: 'Delta Airlines',
+    category: ['Travel'],
+    amount: -320.5,
+  },
+] as const;
+
+export function getFallbackNessieOverview() {
+  return {
+    customerId: DEMO_NESSIE_CUSTOMER_ID,
+    accounts: demoAccounts.map((account) => ({ ...account })),
+    transactions: demoTransactions.map((transaction) => ({ ...transaction })),
+  };
+}

--- a/lib/nessie.ts
+++ b/lib/nessie.ts
@@ -1,20 +1,30 @@
 import type { User } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase/client'
+import { DEMO_NESSIE_CUSTOMER_ID, getFallbackNessieOverview } from '@/data/mock-nessie'
+export { DEMO_NESSIE_CUSTOMER_ID, getFallbackNessieOverview } from '@/data/mock-nessie'
 
 const baseUrl = process.env.NEXT_PUBLIC_NESSIE_BASE_URL ?? 'https://api.nessieisreal.com'
 const apiKey = process.env.NEXT_PUBLIC_NESSIE_API_KEY
+const nessieConfigured = Boolean(apiKey)
+
+class NessieConfigurationError extends Error {
+  constructor() {
+    super('The Nessie API is not configured. Set NEXT_PUBLIC_NESSIE_API_KEY to enable live data.')
+    this.name = 'NessieConfigurationError'
+  }
+}
 
 function buildUrl(path: string, query: Record<string, string | number | undefined> = {}) {
   if (!path.startsWith('/')) {
     throw new Error('Nessie API paths must include a leading slash')
   }
 
-  if (!apiKey) {
-    throw new Error('NEXT_PUBLIC_NESSIE_API_KEY is not defined')
+  if (!nessieConfigured) {
+    throw new NessieConfigurationError()
   }
 
   const url = new URL(path, baseUrl)
-  url.searchParams.set('key', apiKey)
+  url.searchParams.set('key', apiKey!)
 
   Object.entries(query).forEach(([key, value]) => {
     if (value !== undefined && value !== null) {
@@ -26,6 +36,10 @@ function buildUrl(path: string, query: Record<string, string | number | undefine
 }
 
 async function request<T>(path: string, init?: RequestInit & { query?: Record<string, string | number | undefined> }) {
+  if (!nessieConfigured) {
+    throw new NessieConfigurationError()
+  }
+
   const { query, ...requestInit } = init ?? {}
   const response = await fetch(buildUrl(path, query), {
     ...requestInit,
@@ -79,41 +93,55 @@ export async function ensureNessieCustomer(user: User) {
     },
   }
 
-  const customer = await request<{ _id?: string }>('/customers', {
-    method: 'POST',
-    body: JSON.stringify(profile),
-  })
+  try {
+    const customer = await request<{ _id?: string }>('/customers', {
+      method: 'POST',
+      body: JSON.stringify(profile),
+    })
 
-  if (!customer?._id) {
-    throw new Error('Nessie customer creation did not return an id')
+    if (!customer?._id) {
+      throw new Error('Nessie customer creation did not return an id')
+    }
+
+    const { data, error } = await supabase.auth.updateUser({
+      data: {
+        ...(user.user_metadata ?? {}),
+        nessieCustomerId: customer._id,
+      },
+    })
+
+    if (error) {
+      throw error
+    }
+
+    return { customerId: customer._id, user: data?.user ?? user }
+  } catch (error) {
+    if (!(error instanceof NessieConfigurationError)) {
+      console.warn('Falling back to demo Nessie customer', error)
+    }
+    return { customerId: DEMO_NESSIE_CUSTOMER_ID, user }
   }
-
-  const { data, error } = await supabase.auth.updateUser({
-    data: {
-      ...(user.user_metadata ?? {}),
-      nessieCustomerId: customer._id,
-    },
-  })
-
-  if (error) {
-    throw error
-  }
-
-  return { customerId: customer._id, user: data?.user ?? user }
 }
 
 export async function fetchNessieOverview(customerId: string) {
-  if (!customerId) {
-    return { accounts: [], transactions: [] }
+  if (!customerId || customerId === DEMO_NESSIE_CUSTOMER_ID || !nessieConfigured) {
+    return getFallbackNessieOverview()
   }
 
-  const [accounts, transactions] = await Promise.all([
-    request<unknown[]>(`/customers/${customerId}/accounts`),
-    request<unknown[]>(`/customers/${customerId}/transactions`),
-  ])
+  try {
+    const [accounts, transactions] = await Promise.all([
+      request<unknown[]>(`/customers/${customerId}/accounts`),
+      request<unknown[]>(`/customers/${customerId}/transactions`),
+    ])
 
-  return {
-    accounts: Array.isArray(accounts) ? accounts : [],
-    transactions: Array.isArray(transactions) ? transactions : [],
+    return {
+      accounts: Array.isArray(accounts) ? accounts : [],
+      transactions: Array.isArray(transactions) ? transactions : [],
+    }
+  } catch (error) {
+    if (!(error instanceof NessieConfigurationError)) {
+      console.warn('Failed to fetch Nessie data, using demo data instead', error)
+    }
+    return getFallbackNessieOverview()
   }
 }


### PR DESCRIPTION
## Summary
- add reusable mock Nessie overview data for environments without a live API key
- guard Nessie client calls so authentication continues even when the external API is unavailable
- fall back to demo account and transaction data after sign-in so the dashboard always renders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8183ea31c832da79205242998a91a