### PR TITLE
feat: surface dynamic PPP and Nessie insights on dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,20 +9,114 @@ import { Progress } from "@/components/ui/progress"
 import { MapContainer } from "@/components/map-container"
 import { CreditCard, TrendingUp, MapPin, DollarSign } from "lucide-react"
 import { useAuth } from "@/hooks/use-auth"
+import { useUserProfile } from "@/hooks/use-user-profile"
+import { usePPPHighlights } from "@/hooks/use-ppp-highlights"
+import type { NessieTransaction } from "@/lib/nessie"
 
-const mockPPPData = {
-  currentCity: "New York, NY",
-  pppScore: 85,
-  topCities: [
-    { name: "Bangkok, Thailand", savings: 68, pppScore: 92 },
-    { name: "Mexico City, Mexico", savings: 45, pppScore: 88 },
-    { name: "Prague, Czech Republic", savings: 38, pppScore: 86 },
-  ],
+const essentialKeywords = [
+  /rent/i,
+  /mortgage/i,
+  /loan/i,
+  /market/i,
+  /grocery/i,
+  /supermart/i,
+  /utility/i,
+  /electric/i,
+  /power/i,
+  /water/i,
+  /gas/i,
+  /insurance/i,
+  /clinic/i,
+  /pharmacy/i,
+  /hospital/i,
+  /transport/i,
+  /uber/i,
+  /lyft/i,
+]
+
+const experienceKeywords = [
+  /cafe/i,
+  /coffee/i,
+  /restaurant/i,
+  /dining/i,
+  /bar/i,
+  /travel/i,
+  /hotel/i,
+  /airlines/i,
+  /flight/i,
+  /cinema/i,
+  /theater/i,
+  /concert/i,
+  /museum/i,
+  /festival/i,
+  /resort/i,
+  /adventure/i,
+]
+
+function classifyTransaction(transaction: NessieTransaction) {
+  const descriptor = `${transaction.category ?? ""} ${transaction.merchant ?? ""}`.toLowerCase()
+  if (essentialKeywords.some((pattern) => pattern.test(descriptor))) {
+    return "essentials" as const
+  }
+  if (experienceKeywords.some((pattern) => pattern.test(descriptor))) {
+    return "experiences" as const
+  }
+  return "other" as const
+}
+
+function calculateBudgetBuckets(transactions: NessieTransaction[]) {
+  return transactions.reduce(
+    (totals, transaction) => {
+      const bucket = classifyTransaction(transaction)
+      const amount = Math.abs(transaction.amount ?? 0)
+      totals[bucket] += amount
+      totals.total += amount
+      return totals
+    },
+    { essentials: 0, experiences: 0, other: 0, total: 0 },
+  )
+}
+
+function clampPPPScore(value: number | null | undefined) {
+  if (!value || !Number.isFinite(value)) {
+    return null
+  }
+  return Math.max(10, Math.min(200, Math.round(value)))
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function formatCurrencySigned(value: number) {
+  const formatted = formatCurrency(Math.abs(value))
+  return value >= 0 ? `+${formatted}` : `-${formatted}`
+}
+
+function formatPercentage(value: number) {
+  return new Intl.NumberFormat(undefined, {
+    style: "percent",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+function formatPPPIndex(value: number | null | undefined) {
+  if (!value || !Number.isFinite(value)) {
+    return null
+  }
+  return value.toFixed(2)
 }
 
 export default function Dashboard() {
   const { user, loading, nessie, syncingNessie } = useAuth()
   const router = useRouter()
+  const { profile, loading: profileLoading } = useUserProfile(user?.id)
 
   useEffect(() => {
     if (!loading && !user) {
@@ -32,7 +126,67 @@ export default function Dashboard() {
 
   const primaryAccount = useMemo(() => (nessie.accounts.length > 0 ? nessie.accounts[0] : null), [nessie.accounts])
 
-  const transactions = useMemo(() => nessie.transactions.slice(0, 5), [nessie.transactions])
+  const transactions = useMemo(() => {
+    return nessie.transactions
+      .slice()
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+      .slice(0, 5)
+  }, [nessie.transactions])
+
+  const profileBaselinePPP = useMemo(() => {
+    const current = profile?.currentCity?.ppp
+    const fallback = profile?.homeCity?.ppp
+    const candidate = current && current > 0 ? current : fallback && fallback > 0 ? fallback : null
+    return candidate && candidate > 0 ? candidate : null
+  }, [profile])
+
+  const { highlights: pppHighlights, loading: highlightsLoading } = usePPPHighlights({
+    baselinePPP: profileBaselinePPP ?? undefined,
+    excludeCodes: [profile?.currentCity?.code, profile?.homeCity?.code],
+    limit: 12,
+  })
+
+  const topCities = useMemo(() => pppHighlights.slice(0, 3), [pppHighlights])
+  const bestCity = topCities[0] ?? null
+
+  const budgetBuckets = useMemo(() => calculateBudgetBuckets(nessie.transactions), [nessie.transactions])
+
+  const monthlyBudget = profile?.monthlyBudget && profile.monthlyBudget > 0 ? profile.monthlyBudget : null
+  const effectiveBudget = useMemo(() => {
+    if (monthlyBudget && monthlyBudget > 0) {
+      return monthlyBudget
+    }
+    if (budgetBuckets.total > 0) {
+      return budgetBuckets.total
+    }
+    if (primaryAccount?.balance && primaryAccount.balance > 0) {
+      return primaryAccount.balance
+    }
+    return 0
+  }, [monthlyBudget, budgetBuckets.total, primaryAccount?.balance])
+
+  const essentialsProgress = effectiveBudget > 0 ? Math.min(100, (budgetBuckets.essentials / effectiveBudget) * 100) : 0
+  const experiencesProgress = effectiveBudget > 0 ? Math.min(100, (budgetBuckets.experiences / effectiveBudget) * 100) : 0
+  const projectedSavings = Math.max(effectiveBudget - (budgetBuckets.essentials + budgetBuckets.experiences), 0)
+  const savingsProgress = effectiveBudget > 0 ? Math.min(100, (projectedSavings / effectiveBudget) * 100) : 0
+
+  const monthlyPppGain = bestCity && effectiveBudget > 0 ? effectiveBudget * bestCity.savingsRatio : null
+
+  const currentPPPScore = useMemo(() => {
+    const homePPP = profile?.homeCity?.ppp && profile.homeCity.ppp > 0 ? profile.homeCity.ppp : profileBaselinePPP
+    const currentPPP = profile?.currentCity?.ppp && profile.currentCity.ppp > 0 ? profile.currentCity.ppp : profileBaselinePPP
+    if (!homePPP || !currentPPP) {
+      return null
+    }
+    return clampPPPScore((homePPP / currentPPP) * 100)
+  }, [profile?.homeCity?.ppp, profile?.currentCity?.ppp, profileBaselinePPP])
+
+  const currentLocationLabel =
+    profile?.currentCity?.name ?? profile?.currentCountry?.name ?? profile?.homeCity?.name ?? "Update your location in Settings"
+
+  const currentCityPPPIndex = formatPPPIndex(
+    profile?.currentCity?.ppp ?? profile?.homeCity?.ppp ?? profileBaselinePPP ?? null,
+  )
 
   if (!user) {
     return (
@@ -53,11 +207,11 @@ export default function Dashboard() {
         <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-            <p className="text-muted-foreground">Your financial overview and PPP insights</p>
+            <p className="text-muted-foreground">
+              {profileLoading ? "Loading your PPP profile…" : "Your financial overview and PPP insights"}
+            </p>
           </div>
-          {primaryAccount?.currencyCode && (
-            <Badge variant="secondary">{primaryAccount.currencyCode}</Badge>
-          )}
+          {primaryAccount?.currencyCode && <Badge variant="secondary">{primaryAccount.currencyCode}</Badge>}
         </div>
 
         <div className="grid gap-6 md:grid-cols-[1fr_380px]">
@@ -78,53 +232,85 @@ export default function Dashboard() {
                     <div>
                       <p className="text-sm text-muted-foreground">Account Balance</p>
                       <p className="text-2xl font-semibold tracking-tight">
-                        $
-                        {(primaryAccount?.balance ?? 0).toLocaleString(undefined, {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}
+                        {formatCurrency(primaryAccount?.balance ?? 0)}
                       </p>
                       <p className="text-xs text-muted-foreground">
                         {primaryAccount?.type ?? "Checking"} · {primaryAccount?.mask ?? "••••"}
                       </p>
                     </div>
                   </div>
-                  <div className="flex items-center gap-4 rounded-xl bg-muted/30 p-4">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/10">
-                      <TrendingUp className="h-6 w-6 text-emerald-500" />
+                  <div className="flex flex-col gap-3 rounded-xl bg-muted/30 p-4">
+                    <div className="flex items-center gap-4">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/10">
+                        <TrendingUp className="h-6 w-6 text-emerald-500" />
+                      </div>
+                      <div>
+                        <p className="text-sm text-muted-foreground">Monthly PPP Gain</p>
+                        <p className="text-2xl font-semibold tracking-tight">
+                          {monthlyPppGain !== null ? formatCurrencySigned(monthlyPppGain) : "Set your budget"}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {monthlyPppGain !== null && bestCity
+                            ? bestCity.savingsRatio >= 0
+                              ? `Living in ${bestCity.name} could save ${formatPercentage(bestCity.savingsRatio)} each month.`
+                              : `${bestCity.name} is ${formatPercentage(Math.abs(bestCity.savingsRatio))} more expensive than your baseline.`
+                            : "Add a monthly budget in Settings to see PPP savings opportunities."}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <p className="text-sm text-muted-foreground">Monthly PPP Gain</p>
-                      <p className="text-2xl font-semibold tracking-tight">+$642.30</p>
-                      <p className="text-xs text-muted-foreground">vs. last month</p>
-                    </div>
+                    {currentPPPScore && (
+                      <div className="rounded-lg bg-background/60 p-3 text-sm">
+                        <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+                          <span>Current PPP score</span>
+                          <span>{currentPPPScore}/200</span>
+                        </div>
+                        <Progress value={Math.min(100, currentPPPScore)} className="h-2 rounded-full" />
+                      </div>
+                    )}
                   </div>
                 </div>
-                <div className="mt-6">
-                  <p className="mb-2 text-sm font-semibold text-muted-foreground">Budget Allocation</p>
-                  <div className="space-y-4">
-                    <div>
-                      <div className="mb-2 flex items-center justify-between text-sm">
-                        <span>Essentials</span>
-                        <span className="text-muted-foreground">$2,800 / $3,500</span>
-                      </div>
-                      <Progress value={80} className="h-2 rounded-full" />
-                    </div>
-                    <div>
-                      <div className="mb-2 flex items-center justify-between text-sm">
-                        <span>Experiences</span>
-                        <span className="text-muted-foreground">$1,200 / $1,600</span>
-                      </div>
-                      <Progress value={75} className="h-2 rounded-full" />
-                    </div>
-                    <div>
-                      <div className="mb-2 flex items-center justify-between text-sm">
-                        <span>Savings</span>
-                        <span className="text-muted-foreground">$800 / $1,200</span>
-                      </div>
-                      <Progress value={66} className="h-2 rounded-full" />
-                    </div>
+                <div className="mt-6 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-semibold text-muted-foreground">Budget Allocation</p>
+                    <p className="text-xs text-muted-foreground">
+                      Based on {monthlyBudget ? "your monthly budget" : budgetBuckets.total > 0 ? "recent transactions" : "account balance"}
+                    </p>
                   </div>
+                  {effectiveBudget > 0 ? (
+                    <div className="space-y-4">
+                      <div>
+                        <div className="mb-2 flex items-center justify-between text-sm">
+                          <span>Essentials</span>
+                          <span className="text-muted-foreground">
+                            {formatCurrency(budgetBuckets.essentials)} / {formatCurrency(effectiveBudget)}
+                          </span>
+                        </div>
+                        <Progress value={essentialsProgress} className="h-2 rounded-full" />
+                      </div>
+                      <div>
+                        <div className="mb-2 flex items-center justify-between text-sm">
+                          <span>Experiences</span>
+                          <span className="text-muted-foreground">
+                            {formatCurrency(budgetBuckets.experiences)} / {formatCurrency(effectiveBudget)}
+                          </span>
+                        </div>
+                        <Progress value={experiencesProgress} className="h-2 rounded-full" />
+                      </div>
+                      <div>
+                        <div className="mb-2 flex items-center justify-between text-sm">
+                          <span>Savings Potential</span>
+                          <span className="text-muted-foreground">
+                            {formatCurrency(projectedSavings)} / {formatCurrency(effectiveBudget)}
+                          </span>
+                        </div>
+                        <Progress value={savingsProgress} className="h-2 rounded-full" />
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Add transactions or set a monthly budget to unlock allocation insights.
+                    </p>
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -153,7 +339,7 @@ export default function Dashboard() {
                         </p>
                       </div>
                       <span className="font-semibold text-destructive">
-                        ${transaction.amount.toFixed(2)}
+                        -{formatCurrency(transaction.amount)}
                       </span>
                     </div>
                   ))
@@ -171,8 +357,25 @@ export default function Dashboard() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="text-lg font-semibold">{mockPPPData.currentCity}</div>
-                <p className="text-sm text-muted-foreground">Your purchasing power baseline</p>
+                <div className="text-lg font-semibold">{currentLocationLabel}</div>
+                {currentPPPScore ? (
+                  <div className="mt-4 space-y-2">
+                    <div className="flex items-baseline gap-2">
+                      <span className="text-3xl font-bold">{currentPPPScore}</span>
+                      <span className="text-sm text-muted-foreground">PPP score</span>
+                    </div>
+                    <Progress value={Math.min(100, currentPPPScore)} className="h-2 rounded-full" />
+                    {currentCityPPPIndex && (
+                      <p className="text-xs text-muted-foreground">
+                        PPP index: {currentCityPPPIndex}× vs. US baseline
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Set your home and current cities in Settings to unlock PPP scoring.
+                  </p>
+                )}
               </CardContent>
             </Card>
 
@@ -190,24 +393,46 @@ export default function Dashboard() {
         <div className="mt-10">
           <h2 className="mb-4 text-xl font-semibold">Top Cities for Your Money</h2>
           <div className="grid gap-4 md:grid-cols-3">
-            {mockPPPData.topCities.map((city, index) => (
-              <Card key={city.name} className="border-0 bg-card/90 shadow-xl backdrop-blur-sm">
+            {highlightsLoading ? (
+              <Card className="border-0 bg-card/90 shadow-xl backdrop-blur-sm md:col-span-3">
                 <CardContent className="p-6">
-                  <div className="mb-2 flex items-center justify-between">
-                    <Badge variant="secondary">#{index + 1}</Badge>
-                    <div className="text-right">
-                      <span className="text-lg font-bold text-emerald-500">+{city.savings}%</span>
-                    </div>
-                  </div>
-                  <h3 className="mb-1 text-sm font-semibold">{city.name}</h3>
-                  <p className="mb-3 text-xs text-muted-foreground">PPP Score: {city.pppScore}/100</p>
-                  <div className="flex items-center text-xs text-muted-foreground">
-                    <DollarSign className="mr-1 h-3 w-3" />
-                    <span>Your money goes {city.savings}% further</span>
-                  </div>
+                  <p className="text-sm text-muted-foreground">Loading PPP highlights…</p>
                 </CardContent>
               </Card>
-            ))}
+            ) : topCities.length === 0 ? (
+              <Card className="border-0 bg-card/90 shadow-xl backdrop-blur-sm md:col-span-3">
+                <CardContent className="p-6">
+                  <p className="text-sm text-muted-foreground">
+                    Set your preferred cities in Settings to discover where your budget stretches the furthest.
+                  </p>
+                </CardContent>
+              </Card>
+            ) : (
+              topCities.map((city, index) => (
+                <Card key={city.code} className="border-0 bg-card/90 shadow-xl backdrop-blur-sm">
+                  <CardContent className="p-6">
+                    <div className="mb-2 flex items-center justify-between">
+                      <Badge variant="secondary">#{index + 1}</Badge>
+                      <div className="text-right">
+                        <span className="text-lg font-bold text-emerald-500">
+                          {city.savingsRatio >= 0 ? `+${formatPercentage(city.savingsRatio)}` : formatPercentage(city.savingsRatio)}
+                        </span>
+                      </div>
+                    </div>
+                    <h3 className="mb-1 text-sm font-semibold">{city.name}</h3>
+                    <p className="mb-3 text-xs text-muted-foreground">PPP Score: {city.pppScore}/200</p>
+                    <div className="flex items-center text-xs text-muted-foreground">
+                      <DollarSign className="mr-1 h-3 w-3" />
+                      <span>
+                        {city.savingsRatio >= 0
+                          ? `Your money goes ${formatPercentage(city.savingsRatio)} further`
+                          : `${formatPercentage(Math.abs(city.savingsRatio))} higher cost than your baseline`}
+                      </span>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))
+            )}
           </div>
         </div>
       </div>

--- a/hooks/use-ppp-highlights.ts
+++ b/hooks/use-ppp-highlights.ts
@@ -1,0 +1,113 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { supabase } from "@/lib/supabase/client"
+
+export interface PPPHighlight {
+  code: string
+  name: string
+  flag: string | null
+  ppp: number
+  savingsRatio: number
+  savingsPercent: number
+  pppScore: number
+}
+
+interface UsePPPHighlightsOptions {
+  baselinePPP?: number | null
+  excludeCodes?: Array<string | null | undefined>
+  limit?: number
+}
+
+interface UsePPPHighlightsResult {
+  highlights: PPPHighlight[]
+  loading: boolean
+  error: Error | null
+}
+
+function clampScore(value: number) {
+  if (Number.isNaN(value) || !Number.isFinite(value)) {
+    return 100
+  }
+  return Math.max(10, Math.min(200, Math.round(value)))
+}
+
+export function usePPPHighlights(options: UsePPPHighlightsOptions = {}): UsePPPHighlightsResult {
+  const { baselinePPP, excludeCodes, limit = 12 } = options
+  const [highlights, setHighlights] = useState<PPPHighlight[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  const exclusion = useMemo(() => {
+    return new Set((excludeCodes ?? []).filter((code): code is string => typeof code === "string" && code.length > 0))
+  }, [excludeCodes])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const { data, error: queryError } = await supabase
+          .from("ppp_city")
+          .select("code, name, flag, ppp")
+          .not("ppp", "is", null)
+          .gt("ppp", 0)
+          .order("ppp", { ascending: true })
+          .limit(limit)
+
+        if (queryError) {
+          throw queryError
+        }
+
+        const baseline = baselinePPP && baselinePPP > 0 ? baselinePPP : 1
+
+        const processed = (data ?? [])
+          .filter((city) => !exclusion.has(city.code ?? ""))
+          .map((city) => {
+            const pppValue = Number(city.ppp)
+            const ratio = baseline > 0 ? (baseline - pppValue) / baseline : 0
+            const score = baseline > 0 && pppValue > 0 ? (baseline / pppValue) * 100 : 100
+
+            return {
+              code: city.code ?? "",
+              name: city.name ?? "",
+              flag: city.flag ?? null,
+              ppp: pppValue,
+              savingsRatio: ratio,
+              savingsPercent: Math.round(ratio * 100),
+              pppScore: clampScore(score),
+            }
+          })
+          .filter((item) => item.code && item.name && Number.isFinite(item.ppp) && item.ppp > 0)
+          .sort((a, b) => b.savingsRatio - a.savingsRatio)
+          .slice(0, limit)
+
+        if (!cancelled) {
+          setHighlights(processed)
+        }
+      } catch (caught) {
+        if (cancelled) return
+        const normalisedError =
+          caught instanceof Error ? caught : new Error(typeof caught === "string" ? caught : "Failed to load PPP highlights")
+        setError(normalisedError)
+        setHighlights([])
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [baselinePPP, exclusion, limit])
+
+  return { highlights, loading, error }
+}
+


### PR DESCRIPTION
## Summary
- replace mocked dashboard values with live Nessie account and Supabase PPP dataset insights
- add a reusable hook for fetching PPP highlights and wire it into the dashboard
- compute monthly PPP savings, budget allocation, and top city recommendations dynamically

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d81d96d02c8331affc0a1e3d39a6af