### PR TITLE
Optimize parallax hook for smoother scrolling

### DIFF
--- a/src/hooks/useParallax.js
+++ b/src/hooks/useParallax.js
@@ -1,22 +1,48 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const EPSILON = 0.5;
 
 export function useParallax(multiplier = 0.3) {
   const [offset, setOffset] = useState(0);
+  const multiplierRef = useRef(multiplier);
 
   useEffect(() => {
-    const handleScroll = () => {
-      setOffset(window.scrollY * multiplier);
-    };
-
-    handleScroll();
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
+    multiplierRef.current = multiplier;
   }, [multiplier]);
 
-  return {
-    offset,
-    style: {
-      transform: `translateY(${offset * -1}px)`
-    }
-  };
+  useEffect(() => {
+    let frameId = null;
+
+    const updateOffset = () => {
+      frameId = null;
+      const next = window.scrollY * multiplierRef.current;
+      setOffset((previous) => (Math.abs(previous - next) < EPSILON ? previous : next));
+    };
+
+    const scheduleUpdate = () => {
+      if (frameId !== null) return;
+      frameId = window.requestAnimationFrame(updateOffset);
+    };
+
+    scheduleUpdate();
+    window.addEventListener('scroll', scheduleUpdate, { passive: true });
+    window.addEventListener('resize', scheduleUpdate, { passive: true });
+
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      window.removeEventListener('scroll', scheduleUpdate);
+      window.removeEventListener('resize', scheduleUpdate);
+    };
+  }, []);
+
+  const style = useMemo(
+    () => ({
+      transform: `translate3d(0, ${-offset}px, 0)`
+    }),
+    [offset]
+  );
+
+  return { offset, style };
 }


### PR DESCRIPTION
## Summary
- throttle the parallax hook with requestAnimationFrame to avoid redundant renders and keep multiplier updates stable
- memoize the generated transform style so hero sections use translate3d for cheaper GPU compositing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d827c75238832dbc75a3eff9c2be9c