### PR TITLE
feat: add personalized onboarding and richer insights

### DIFF
--- a/src/components/dashboard/NotificationsWidget.jsx
+++ b/src/components/dashboard/NotificationsWidget.jsx
@@ -1,0 +1,33 @@
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card.jsx';
+
+export function NotificationsWidget({ items = [] }) {
+  const messages = items.filter(Boolean);
+  return (
+    <Card className="bg-white/85">
+      <CardHeader>
+        <CardTitle>Latest nudges</CardTitle>
+        <p className="text-sm text-charcoal/70">We turn PPP swings into actionable moves.</p>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {messages.map((message, index) => (
+            <li
+              key={`${message}-${index}`}
+              className="flex items-start gap-3 rounded-2xl border border-teal/20 bg-turquoise/10 px-4 py-3 text-sm text-charcoal"
+            >
+              <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-teal" aria-hidden="true" />
+              <p>{message}</p>
+            </li>
+          ))}
+          {messages.length === 0 && (
+            <li className="rounded-2xl border border-dashed border-navy/20 px-4 py-6 text-center text-sm text-charcoal/60">
+              Once we have enough data we’ll start dropping personalised travel plays here.
+            </li>
+          )}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default NotificationsWidget;

--- a/src/components/dashboard/SavingsRunwayPanel.jsx
+++ b/src/components/dashboard/SavingsRunwayPanel.jsx
@@ -1,0 +1,53 @@
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card.jsx';
+
+function formatRunway(months) {
+  if (!Number.isFinite(months) || months <= 0) return 'N/A';
+  const years = Math.floor(months / 12);
+  const remainingMonths = Math.round((months % 12) * 10) / 10;
+  if (years <= 0) return `${months.toFixed(1)} months`;
+  const parts = [];
+  if (years > 0) parts.push(`${years} year${years > 1 ? 's' : ''}`);
+  if (remainingMonths > 0) parts.push(`${remainingMonths.toFixed(1)} month${remainingMonths !== 1 ? 's' : ''}`);
+  return parts.join(' ');
+}
+
+export function SavingsRunwayPanel({ destinations = [], stayLengthMonths = 6 }) {
+  const topThree = destinations.slice(0, 3);
+
+  return (
+    <Card className="bg-white/85">
+      <CardHeader>
+        <CardTitle>Savings runway</CardTitle>
+        <p className="text-sm text-charcoal/70">
+          At your budget you could sustain this lifestyle for <strong>{stayLengthMonths}</strong> month
+          {stayLengthMonths === 1 ? '' : 's'}.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-4">
+          {topThree.map((destination) => (
+            <li key={destination.city} className="flex items-start justify-between rounded-2xl bg-offwhite/70 px-4 py-3 shadow-sm">
+              <div>
+                <p className="font-semibold text-teal">{destination.city}</p>
+                <p className="text-xs text-charcoal/60">
+                  PPP score {destination.ppp?.toFixed?.(0) ?? '—'} · {destination.context ?? 'Balanced cost breakdown'}
+                </p>
+              </div>
+              <div className="text-right text-sm">
+                <p className="font-semibold text-charcoal">{formatRunway(destination.runwayMonths)}</p>
+                <p className="text-xs text-charcoal/60">${Number(destination.monthlyCost ?? 0).toLocaleString()}/mo</p>
+              </div>
+            </li>
+          ))}
+          {topThree.length === 0 && (
+            <li className="rounded-2xl border border-dashed border-navy/20 px-4 py-6 text-center text-sm text-charcoal/60">
+              We’ll surface destinations once your PPP feed is ready.
+            </li>
+          )}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default SavingsRunwayPanel;

--- a/src/components/dashboard/SpendingTrendChart.jsx
+++ b/src/components/dashboard/SpendingTrendChart.jsx
@@ -1,0 +1,67 @@
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+const tooltipStyles = {
+  backgroundColor: 'rgba(20, 33, 61, 0.92)',
+  borderRadius: '12px',
+  border: 'none',
+  color: '#FAF9F6',
+  padding: '12px 16px',
+};
+
+export function SpendingTrendChart({ data = [] }) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return (
+      <div className="flex h-60 items-center justify-center rounded-3xl border border-dashed border-navy/20 bg-white/60 text-sm text-charcoal/50">
+        No transactions yet — once you sync a card we’ll chart your trend here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-60 w-full overflow-hidden rounded-3xl border border-white/40 bg-white/80 p-4 shadow-inner shadow-teal/10">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data}>
+          <defs>
+            <linearGradient id="trend" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#2EC4B6" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="#2EC4B6" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(13,59,102,0.08)" />
+          <XAxis dataKey="label" stroke="#2B2B2B" fontSize={12} tickLine={false} axisLine={false} />
+          <YAxis
+            stroke="#2B2B2B"
+            fontSize={12}
+            tickFormatter={(value) => `$${Math.round(value)}`}
+            axisLine={false}
+            tickLine={false}
+          />
+          <Tooltip
+            contentStyle={tooltipStyles}
+            formatter={(value) => [`$${Number(value).toLocaleString()}`, 'Spent']}
+            labelFormatter={(label) => `Week of ${label}`}
+          />
+          <Area
+            type="monotone"
+            dataKey="amount"
+            stroke="#2EC4B6"
+            strokeWidth={3}
+            fill="url(#trend)"
+            dot={{ stroke: '#EE6C4D', strokeWidth: 2, r: 4 }}
+            activeDot={{ r: 6, fill: '#EE6C4D' }}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export default SpendingTrendChart;

--- a/src/components/insights/CategoryTile.jsx
+++ b/src/components/insights/CategoryTile.jsx
@@ -1,6 +1,6 @@
 import { Card } from '../ui/Card.jsx';
 
-export function CategoryTile({ title, description, delta }) {
+export function CategoryTile({ title, description, delta, recommendation }) {
   const deltaLabel = delta >= 0 ? `Save ${delta.toFixed(0)}%` : `Spend ${Math.abs(delta).toFixed(0)}% more`;
   const deltaColor = delta >= 0 ? 'text-teal' : 'text-coral';
 
@@ -9,6 +9,7 @@ export function CategoryTile({ title, description, delta }) {
       <h4 className="font-poppins text-lg font-semibold text-charcoal">{title}</h4>
       <p className="mt-2 text-sm text-charcoal/70">{description}</p>
       <p className={`mt-3 text-sm font-semibold ${deltaColor}`}>{deltaLabel}</p>
+      {recommendation && <p className="mt-3 text-xs text-charcoal/60">{recommendation}</p>}
     </Card>
   );
 }

--- a/src/components/insights/ComparisonChart.jsx
+++ b/src/components/insights/ComparisonChart.jsx
@@ -1,35 +1,45 @@
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis
-} from 'recharts';
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 const tooltipStyles = {
   backgroundColor: 'rgba(13, 59, 102, 0.9)',
   color: '#FAF9F6',
   borderRadius: '12px',
   padding: '12px 16px',
-  border: 'none'
+  border: 'none',
 };
 
 export function ComparisonChart({ data }) {
+  const categories = ['Rent', 'Groceries', 'Transport'];
+
   return (
-    <div className="h-72 w-full overflow-hidden rounded-3xl border border-white/50 bg-white/75 p-4 shadow-inner shadow-teal/10">
+    <div className="h-80 w-full overflow-hidden rounded-3xl border border-white/50 bg-white/75 p-4 shadow-inner shadow-teal/10">
       <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data}>
+        <BarChart data={data} stackOffset="expand">
           <CartesianGrid strokeDasharray="3 3" stroke="rgba(13,59,102,0.08)" />
           <XAxis dataKey="city" stroke="#2B2B2B" fontSize={12} tickLine={false} axisLine={false} />
-          <YAxis stroke="#2B2B2B" fontSize={12} tickFormatter={(value) => `${value}%`} axisLine={false} tickLine={false} />
+          <YAxis
+            stroke="#2B2B2B"
+            fontSize={12}
+            tickFormatter={(value) => `${Math.round(value * 100)}%`}
+            axisLine={false}
+            tickLine={false}
+            domain={[0, 1]}
+          />
           <Tooltip
             contentStyle={tooltipStyles}
             cursor={{ fill: 'rgba(46,196,182,0.08)' }}
-            formatter={(value, name) => [`${value}%`, name === 'value' ? 'Savings' : name]}
+            formatter={(value, name) => [`${Math.round(value * 100)}%`, name]}
           />
-          <Bar dataKey="value" radius={[12, 12, 12, 12]} fill="#2EC4B6" />
+          <Legend verticalAlign="top" height={36} iconType="circle" />
+          {categories.map((category, index) => (
+            <Bar
+              key={category}
+              dataKey={category}
+              stackId="spend"
+              fill={[ '#2EC4B6', '#EE6C4D', '#3D5A80' ][index]}
+              radius={index === categories.length - 1 ? [0, 0, 12, 12] : [12, 12, 0, 0]}
+            />
+          ))}
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button.jsx';
 import { useAuth } from '../../hooks/useAuth.js';
@@ -21,6 +21,22 @@ export function NavBar() {
   const navigate = useNavigate();
   const { user, signOut, isLoading } = useAuth();
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === 'undefined') return 'light';
+    return window.localStorage.getItem('ppp-theme') ?? 'light';
+  });
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.setAttribute('data-theme', theme);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('ppp-theme', theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  };
   const links = user ? authenticatedLinks : [];
 
   const identityLabel = useMemo(() => {
@@ -77,6 +93,13 @@ export function NavBar() {
 
         {/* ✅ Changed: Better account section layout */}
         <div className="hidden items-center gap-5 md:flex border-l border-slate/200 pl-6">
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className="rounded-full border border-navy/20 bg-white px-3 py-2 text-xs font-semibold text-navy/70 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+          >
+            {theme === 'dark' ? '☀️ Light' : '🌙 Dark'}
+          </button>
           {user ? (
             <>
               {/* ✅ User label + icon link to settings */}
@@ -137,9 +160,16 @@ export function NavBar() {
                   </NavLink>
                 </li>
               ))}
-              <li className="pt-3">
+             <li className="pt-3">
                 {user ? (
                   <div className="space-y-2">
+                    <button
+                      type="button"
+                      onClick={toggleTheme}
+                      className="w-full rounded-full border border-navy/20 bg-white px-4 py-2 text-xs font-semibold text-navy/70 shadow-sm transition hover:bg-navy/5"
+                    >
+                      {theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                    </button>
                     <NavLink
                       to="/settings"
                       className="flex items-center gap-2 text-sm font-semibold text-navy/70 hover:text-navy"
@@ -159,6 +189,13 @@ export function NavBar() {
                   </div>
                 ) : (
                   <div className="space-y-2">
+                    <button
+                      type="button"
+                      onClick={toggleTheme}
+                      className="w-full rounded-full border border-navy/20 bg-white px-4 py-2 text-xs font-semibold text-navy/70 shadow-sm transition hover:bg-navy/5"
+                    >
+                      {theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                    </button>
                     <Button as={NavLink} to="/login" variant="secondary" className="w-full text-sm">
                       Log in
                     </Button>

--- a/src/components/onboarding/OnboardingModal.jsx
+++ b/src/components/onboarding/OnboardingModal.jsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import Button from '../ui/Button.jsx';
+
+const TRAVEL_GOALS = ['Digital nomad life', 'Short-term relocation', 'Long sabbatical', 'Budget world tour'];
+const TRAVEL_STYLES = ['Comfort seeker', 'Local immersion', 'Luxury explorer', 'Remote worker'];
+const BUDGET_FOCUS = ['Rent', 'Food', 'Leisure', 'Balanced'];
+
+function normaliseCities(value) {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((city) => city.trim())
+    .filter(Boolean);
+}
+
+export function OnboardingModal({
+  isOpen,
+  defaultValues = {},
+  onComplete,
+  onSkip,
+  displayName,
+}) {
+  const [travelGoal, setTravelGoal] = useState(defaultValues.travelGoal ?? 'Digital nomad life');
+  const [travelStyle, setTravelStyle] = useState(defaultValues.travelStyle ?? 'Local immersion');
+  const [budgetFocus, setBudgetFocus] = useState(defaultValues.budgetFocus ?? 'Balanced');
+  const [monthlyBudget, setMonthlyBudget] = useState(() => {
+    if (typeof defaultValues.monthlyBudget === 'number' && Number.isFinite(defaultValues.monthlyBudget)) {
+      return String(defaultValues.monthlyBudget);
+    }
+    return '';
+  });
+  const [cityInput, setCityInput] = useState((defaultValues.curiousCities ?? []).join(', '));
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setTravelGoal(defaultValues.travelGoal ?? 'Digital nomad life');
+    setTravelStyle(defaultValues.travelStyle ?? 'Local immersion');
+    setBudgetFocus(defaultValues.budgetFocus ?? 'Balanced');
+    setMonthlyBudget(
+      typeof defaultValues.monthlyBudget === 'number' && Number.isFinite(defaultValues.monthlyBudget)
+        ? String(defaultValues.monthlyBudget)
+        : ''
+    );
+    setCityInput((defaultValues.curiousCities ?? []).join(', '));
+  }, [defaultValues, isOpen]);
+
+  const parsedBudget = useMemo(() => {
+    const numeric = Number(monthlyBudget);
+    if (!Number.isFinite(numeric) || numeric <= 0) return null;
+    return numeric;
+  }, [monthlyBudget]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!parsedBudget) {
+      setError('Tell us roughly how much you spend each month so we can plan smarter.');
+      return;
+    }
+    setError(null);
+    const payload = {
+      travelGoal,
+      travelStyle,
+      budgetFocus,
+      monthlyBudget: parsedBudget,
+      curiousCities: normaliseCities(cityInput),
+    };
+    onComplete?.(payload);
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-navy/70 px-4"
+        >
+          <motion.div
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            transition={{ type: 'spring', damping: 18, stiffness: 200 }}
+            className="relative w-full max-w-2xl rounded-3xl bg-offwhite p-8 shadow-2xl"
+          >
+            <div className="absolute right-6 top-6 text-xs uppercase tracking-[0.3em] text-teal/60">Welcome</div>
+            <h2 className="pr-12 font-poppins text-3xl font-semibold text-navy">
+              {displayName ? `Hey ${displayName.split(' ')[0]},` : 'Hey there,'}
+              <br />
+              let’s personalise your dashboard.
+            </h2>
+            <p className="mt-3 text-sm text-charcoal/70">
+              Answer a few quick questions so we can tailor cities, insights, and savings for you.
+            </p>
+
+            <form onSubmit={handleSubmit} className="mt-6 space-y-6">
+              <div>
+                <label className="block text-sm font-semibold text-charcoal">What’s your monthly travel budget?</label>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  min="0"
+                  value={monthlyBudget}
+                  onChange={(event) => setMonthlyBudget(event.target.value)}
+                  className="mt-2 w-full rounded-2xl border border-navy/20 bg-white px-4 py-3 text-sm text-charcoal shadow-sm focus:outline-none focus:ring-2 focus:ring-teal"
+                  placeholder="e.g. 2500"
+                  required
+                />
+              </div>
+
+              <fieldset>
+                <legend className="text-sm font-semibold text-charcoal">Which part of your budget matters most?</legend>
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  {BUDGET_FOCUS.map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      onClick={() => setBudgetFocus(option)}
+                      className={`rounded-2xl border px-4 py-3 text-left text-sm transition hover:-translate-y-0.5 hover:shadow-lg ${
+                        budgetFocus === option
+                          ? 'border-teal bg-turquoise/20 text-teal shadow-md'
+                          : 'border-navy/15 bg-white text-charcoal'
+                      }`}
+                    >
+                      {option}
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+
+              <fieldset>
+                <legend className="text-sm font-semibold text-charcoal">What’s your current travel goal?</legend>
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  {TRAVEL_GOALS.map((option) => (
+                    <label
+                      key={option}
+                      className={`flex cursor-pointer items-center gap-3 rounded-2xl border px-4 py-3 text-sm transition hover:border-teal ${
+                        travelGoal === option ? 'border-teal bg-turquoise/20 text-teal shadow-sm' : 'border-navy/15 bg-white'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="travel-goal"
+                        value={option}
+                        checked={travelGoal === option}
+                        onChange={() => setTravelGoal(option)}
+                        className="h-4 w-4 text-teal focus:ring-teal"
+                      />
+                      {option}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+
+              <fieldset>
+                <legend className="text-sm font-semibold text-charcoal">Describe your travel style</legend>
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  {TRAVEL_STYLES.map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      onClick={() => setTravelStyle(option)}
+                      className={`rounded-2xl border px-4 py-3 text-left text-sm transition hover:-translate-y-0.5 hover:shadow-lg ${
+                        travelStyle === option
+                          ? 'border-coral bg-coral/10 text-coral shadow-md'
+                          : 'border-navy/15 bg-white text-charcoal'
+                      }`}
+                    >
+                      {option}
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+
+              <div>
+                <label className="block text-sm font-semibold text-charcoal">Which cities are you curious about?</label>
+                <p className="text-xs text-charcoal/60">Separate with commas and we’ll highlight them in GeoBudget.</p>
+                <input
+                  type="text"
+                  value={cityInput}
+                  onChange={(event) => setCityInput(event.target.value)}
+                  className="mt-2 w-full rounded-2xl border border-navy/20 bg-white px-4 py-3 text-sm text-charcoal shadow-sm focus:outline-none focus:ring-2 focus:ring-teal"
+                  placeholder="Berlin, Mexico City, Lisbon"
+                />
+              </div>
+
+              {error && <p className="text-sm text-coral">{error}</p>}
+
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <button
+                  type="button"
+                  onClick={onSkip}
+                  className="text-sm font-semibold text-charcoal/70 underline-offset-4 hover:text-charcoal hover:underline"
+                >
+                  Skip for now
+                </button>
+                <Button type="submit" className="justify-center">
+                  Personalise my dashboard
+                </Button>
+              </div>
+            </form>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export default OnboardingModal;

--- a/src/components/planner/RunwayCard.jsx
+++ b/src/components/planner/RunwayCard.jsx
@@ -1,55 +1,80 @@
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import { Card } from '../ui/Card.jsx';
 import Progress from '../ui/Progress.jsx';
 
-// Helper function to safely apply .toFixed
-function safeToFixed(value, digits = 1) {
-  const num = parseFloat(value);
-  return isNaN(num) ? '0.0' : num.toFixed(digits);
-}
-
-// Format runway into months or years + months
 function formatRunway(runway) {
-  const num = parseFloat(runway);
-  if (isNaN(num) || num < 0) return '0.0 months';
-
-  if (num <= 12) {
-    return `${num.toFixed(1)} months`;
-  }
-
-  const totalMonths = Math.round(num * 10) / 10; // preserve decimal for months
-  const years = Math.floor(totalMonths / 12);
-  const months = Math.round((totalMonths % 12) * 10) / 10;
-
-  let result = '';
-  if (years > 0) result += `${years} year${years > 1 ? 's' : ''}`;
-  if (months > 0) result += ` ${months.toFixed(1)} month${months !== 1 ? 's' : ''}`;
-
-  return result.trim();
+  const num = Number(runway);
+  if (!Number.isFinite(num) || num <= 0) return '0.0 months';
+  if (num < 12) return `${num.toFixed(1)} months`;
+  const years = Math.floor(num / 12);
+  const months = Math.round((num % 12) * 10) / 10;
+  const parts = [];
+  if (years > 0) parts.push(`${years} year${years > 1 ? 's' : ''}`);
+  if (months > 0) parts.push(`${months.toFixed(1)} month${months !== 1 ? 's' : ''}`);
+  return parts.join(' ');
 }
 
-export function RunwayCard({ city, runway, monthlyCost, currency = 'USD' }) {
-  const percent = Math.min(100, (runway / 12) * 100);
+function formatCurrency(amount, currency) {
+  if (!Number.isFinite(amount)) return '—';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(amount);
+}
 
-  const formattedCost = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
-  }).format(monthlyCost || 0);
+export function RunwayCard({
+  city,
+  runway,
+  monthlyCost,
+  currency = 'USD',
+  stayDurationMonths = 6,
+  breakdown = {},
+  isHighlighted = false,
+  badgeLabel = null,
+}) {
+  const percent = Math.min(100, (Number(runway) / stayDurationMonths) * 100);
+  const stayCost = Number(monthlyCost) * stayDurationMonths;
+
+  const segments = Object.entries(breakdown);
 
   return (
-    <Card className="bg-white/80">
-      <div className="flex items-center justify-between">
-        <h4 className="font-poppins text-lg font-semibold text-teal">{city}</h4>
+    <Card
+      className={`relative bg-white/85 transition-all duration-200 hover:-translate-y-1 hover:shadow-2xl ${
+        isHighlighted ? 'ring-2 ring-teal shadow-lg' : ''
+      }`}
+    >
+      {(isHighlighted || badgeLabel) && (
+        <span className="absolute -top-3 left-4 rounded-full bg-coral px-3 py-1 text-xs font-semibold text-white">
+          {badgeLabel ?? 'Best pick'}
+        </span>
+      )}
+      <div className="flex items-start justify-between">
+        <div>
+          <h4 className="font-poppins text-lg font-semibold text-teal">{city}</h4>
+          <p className="mt-1 text-xs text-charcoal/60">PPP-adjusted budget fit</p>
+        </div>
         <span className="rounded-full bg-turquoise/20 px-3 py-1 text-xs font-semibold text-teal">
           {formatRunway(runway)}
         </span>
       </div>
       <p className="mt-3 text-sm text-charcoal/70">
-        PPP-adjusted cost ≈ {formattedCost} /mo
+        {formatCurrency(monthlyCost, currency)} /mo · {formatCurrency(stayCost, currency)} for {stayDurationMonths} month
+        {stayDurationMonths === 1 ? '' : 's'}
       </p>
       <Progress value={percent} className="mt-4" />
-      <p className="mt-2 text-xs text-charcoal/60">
-        12 months = fully funded. Track your runway with PPP awareness.
-      </p>
+      <div className="mt-3 flex items-start gap-2 text-xs text-charcoal/70">
+        <InformationCircleIcon className="mt-0.5 h-4 w-4 text-teal" aria-hidden="true" />
+        <div>
+          {segments.length > 0 ? (
+            <ul className="space-y-1">
+              {segments.map(([label, value]) => (
+                <li key={label}>
+                  <span className="font-semibold text-charcoal">{label}:</span> {Math.round(value * 100)}% of spend
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>We estimate your rent, food, and leisure mix using PPP data.</p>
+          )}
+        </div>
+      </div>
     </Card>
   );
 }

--- a/src/components/score/CityCard.jsx
+++ b/src/components/score/CityCard.jsx
@@ -1,30 +1,34 @@
 import { Card } from '../ui/Card.jsx';
 import Progress from '../ui/Progress.jsx';
 
-export function CityCard({ city, savings, monthlyCost, currency = 'USD' }) {
-  const formattedSavings =
-    savings > 0
-      ? `Save ${savings.toFixed(0)}% vs. Atlanta`
-      : `Spend ${Math.abs(savings).toFixed(0)}% more`;
+function normaliseSavings(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return 0;
+}
 
-  const formattedCost = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
-  }).format(monthlyCost);
+export function CityCard({ city, savings, savingsPct, monthlyCost, currency = 'USD', ppp }) {
+  const effectiveSavings = normaliseSavings(savings ?? savingsPct ?? 0);
+  const formattedSavings =
+    effectiveSavings > 0
+      ? `Save ${effectiveSavings.toFixed(0)}% vs. your baseline`
+      : `Spend ${Math.abs(effectiveSavings).toFixed(0)}% more`; // negative indicates more expensive
+
+  const formattedCost = Number.isFinite(monthlyCost)
+    ? new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+      }).format(monthlyCost)
+    : '—';
+
+  const progressValue = Math.min(100, Math.max(8, 50 + effectiveSavings));
 
   return (
-    <Card className="bg-white/80">
+    <Card className="bg-white/80 transition hover:-translate-y-1 hover:shadow-xl">
       <h4 className="font-poppins text-lg font-semibold text-teal">{city}</h4>
-      <p className="mt-2 text-sm text-charcoal/70">
-        Monthly PPP cost ≈ {formattedCost}
-      </p>
-      <p className="mt-3 text-sm font-semibold text-turquoise">
-        {formattedSavings}
-      </p>
-      <Progress
-        value={Math.min(100, Math.max(10, 50 + savings))}
-        className="mt-4"
-      />
+      <p className="mt-1 text-xs uppercase tracking-[0.3em] text-charcoal/50">PPP {ppp ? ppp.toFixed(1) : '—'}</p>
+      <p className="mt-2 text-sm text-charcoal/70">Monthly PPP cost ≈ {formattedCost}</p>
+      <p className="mt-3 text-sm font-semibold text-turquoise">{formattedSavings}</p>
+      <Progress value={progressValue} className="mt-4" />
     </Card>
   );
 }

--- a/src/components/score/WorldMap.jsx
+++ b/src/components/score/WorldMap.jsx
@@ -42,9 +42,19 @@ export function WorldMap({ markers = [] }) {
         color: '#2EC4B6',
         weight: 2,
         fillColor: '#EE6C4D',
-        fillOpacity: 0.7
+        fillOpacity: 0.75,
+        className: 'ppp-circle-marker'
       });
-      circle.bindPopup(`<strong>${marker.city}</strong><br/>PPP: ${marker.ppp.toFixed(2)}`);
+      const tooltipHtml = `<div class="text-sm"><strong>${marker.city}</strong><br/>PPP score ${marker.ppp.toFixed(
+        1
+      )}<br/><span style="opacity:0.7;">${marker.context ?? 'Hover to compare with your base city'}</span></div>`;
+      circle.bindPopup(tooltipHtml);
+      circle.bindTooltip(tooltipHtml, {
+        direction: 'top',
+        offset: [0, -8],
+        opacity: 0.9,
+        sticky: true
+      });
       circle.addTo(map);
       layersRef.current.push(circle);
     });

--- a/src/components/share/ShareSummary.jsx
+++ b/src/components/share/ShareSummary.jsx
@@ -1,21 +1,57 @@
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 import { Card } from '../ui/Card.jsx';
 
-export const ShareSummary = forwardRef(function ShareSummary({ bestCity, score, balance }, ref) {
+function formatCurrency(value) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(Number(value) ?? 0);
+}
+
+function getFlagEmoji(name) {
+  if (!name) return '🌍';
+  const country = name.split(',')[0].trim().toUpperCase();
+  if (country.length !== 2) return '🌍';
+  const codePoints = [...country].map((char) => 127397 + char.charCodeAt(0));
+  return String.fromCodePoint(...codePoints);
+}
+
+export const ShareSummary = forwardRef(function ShareSummary({ bestCity, score, balance, baselineCountry }, ref) {
+  const flagSource = bestCity?.code ?? bestCity?.countryCode ?? bestCity?.country ?? '';
+  const flag = useMemo(() => getFlagEmoji(flagSource), [flagSource]);
+  const savingsLabel = bestCity?.savings != null ? `${Math.round(bestCity.savings)}% savings` : 'Savings ready';
+
   return (
-    <Card ref={ref} className="mx-auto w-full max-w-xl bg-white/90 text-center">
-      <p className="text-xs font-semibold uppercase tracking-[0.4em] text-teal/70">Parity</p>
-      <h2 className="mt-2 text-3xl font-poppins font-semibold text-teal">Your Parity summary</h2>
-      <p className="mt-4 text-sm text-charcoal/70">
-        With a balance of <span className="font-semibold text-teal">{new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(balance)}</span>, your purchasing power index
-        scores <span className="font-semibold text-turquoise">{score}</span>.
-      </p>
-      <div className="mt-6 rounded-3xl border border-teal/30 bg-turquoise/10 px-6 py-5">
-        <p className="text-xs uppercase tracking-[0.4em] text-teal/70">Best value destination</p>
-        <h3 className="mt-2 text-2xl font-poppins font-semibold text-teal">{bestCity.city}</h3>
-        <p className="mt-2 text-sm text-charcoal/70">Save up to {bestCity.savings.toFixed(0)}% vs. staying in Atlanta.</p>
+    <Card
+      ref={ref}
+      className="mx-auto w-full max-w-xl overflow-hidden rounded-3xl bg-gradient-to-br from-white via-sky/20 to-offwhite text-center shadow-2xl"
+    >
+      <div className="flex items-center justify-between border-b border-white/40 px-6 py-4 text-xs uppercase tracking-[0.4em] text-teal/70">
+        <span>{baselineCountry} • PPP passport</span>
+        <span>{new Date().toLocaleDateString()}</span>
       </div>
-      <p className="mt-6 text-xs text-charcoal/60">Export this card as a PNG or PDF to share Parity insights with your travel crew.</p>
+      <div className="px-8 py-10">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-turquoise/20 text-3xl">{flag}</div>
+        <h2 className="mt-4 text-3xl font-poppins font-semibold text-teal">Your travel power snapshot</h2>
+        <p className="mt-3 text-sm text-charcoal/70">
+          Balance {formatCurrency(balance)} · PPP score <span className="font-semibold text-turquoise">{score}</span>
+        </p>
+        <div className="mt-6 rounded-3xl border border-teal/40 bg-white/80 px-6 py-5 shadow-inner shadow-teal/10">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-teal/70">Best destination</p>
+          <h3 className="mt-2 text-2xl font-poppins font-semibold text-teal">{bestCity?.city ?? 'Loading'}</h3>
+          <p className="text-xs uppercase tracking-[0.3em] text-coral/70">{savingsLabel}</p>
+          <p className="mt-3 text-sm text-charcoal/70">
+            Stretch your budget longer in {bestCity?.city}. PPP score advantage lets you bank the difference.
+          </p>
+        </div>
+        <div className="mt-8 grid grid-cols-2 gap-3 text-left text-xs text-charcoal/60">
+          <div>
+            <p className="font-semibold text-charcoal">GeoBudget insight</p>
+            <p>Longest runway: {bestCity?.runwayLabel ?? 'Ready when you are'}.</p>
+          </div>
+          <div>
+            <p className="font-semibold text-charcoal">Smart-Spend cue</p>
+            <p>Reallocate {bestCity?.savings > 0 ? 'savings' : 'funds'} to experiences without breaking budget.</p>
+          </div>
+        </div>
+      </div>
     </Card>
   );
 });

--- a/src/components/share/SocialButtons.jsx
+++ b/src/components/share/SocialButtons.jsx
@@ -1,0 +1,50 @@
+import Button from '../ui/Button.jsx';
+
+export function SocialButtons({ summaryRef }) {
+  const shareText = 'My PPP Passport shows where my dollars stretch the furthest. ✈️';
+  const shareUrl = typeof window !== 'undefined' ? window.location.origin : 'https://ppp-pocket.example';
+
+  const shareTo = (network) => {
+    const url = encodeURIComponent(shareUrl);
+    const text = encodeURIComponent(shareText);
+    let target = '';
+    if (network === 'twitter') {
+      target = `https://twitter.com/intent/tweet?text=${text}&url=${url}`;
+    } else if (network === 'linkedin') {
+      target = `https://www.linkedin.com/sharing/share-offsite/?url=${url}`;
+    } else if (network === 'copy') {
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        navigator.clipboard.writeText(`${shareText} ${shareUrl}`);
+      }
+      return;
+    }
+    if (target) {
+      window.open(target, '_blank', 'noopener,noreferrer,width=600,height=700');
+    }
+  };
+
+  const nativeShare = async () => {
+    if (navigator.share && summaryRef?.current) {
+      await navigator.share({ title: 'PPP Passport', text: shareText, url: shareUrl });
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-3">
+      <Button variant="secondary" onClick={() => shareTo('twitter')}>
+        Share to X
+      </Button>
+      <Button variant="secondary" onClick={() => shareTo('linkedin')}>
+        Share to LinkedIn
+      </Button>
+      <Button variant="ghost" onClick={() => shareTo('copy')}>
+        Copy link
+      </Button>
+      <Button variant="secondary" onClick={nativeShare}>
+        Quick share
+      </Button>
+    </div>
+  );
+}
+
+export default SocialButtons;

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -9,7 +9,7 @@ const variants = {
   secondary:
     'bg-offwhite text-navy border border-navy hover:bg-navy hover:text-offwhite focus-visible:outline-navy',
   ghost:
-    'bg-transparent text-offwhite border border-offwhite hover:bg-offwhite hover:text-navy focus-visible:outline-offwhite'
+    'bg-transparent text-navy border border-navy/40 hover:bg-navy hover:text-offwhite focus-visible:outline-navy'
 };
 
 export function Button({ as: Component = 'button', variant = 'primary', className, children, ...props }) {

--- a/src/hooks/usePPP.js
+++ b/src/hooks/usePPP.js
@@ -1,26 +1,19 @@
-// Calculate realistic monthly living costs in USD equivalent
-  const estimateMonthlyLivingCost = (pppIndex) => {
-    // Base comfortable living cost in USD (what $2000 buys in the US)
-    const baseComfortableLivingUSD = 2000; 
-    
-    // In countries with high PPP index (cheap countries), 
-    // the same lifestyle costs much less in USD terms
-    const equivalentUSDCost = baseComfortableLivingUSD / pppIndex;
-    
-    // Sanity check: don't let it go below $100 or above $8000
-    const clampedCost = Math.max(100, Math.min(8000, equivalentUSDCost));
-    
-    console.log(`Monthly cost estimate: PPP ${pppIndex} → ${clampedCost.toFixed(0)}/month USD equivalent`);
-    
-    return Math.round(clampedCost);
-  };import { useEffect, useMemo, useState, useCallback } from 'react';
-import supabase, { 
-  getPurchasingPowerRatio, 
-  getAdjustedPrice, 
-  calculateLivingTime,
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  getPurchasingPowerRatio,
+  getAdjustedPrice,
   calculateBudgetRunway,
-  getAllCountries 
+  getAllCountries,
 } from '../Econ.js';
+
+function estimateMonthlyLivingCost(pppIndex) {
+  if (!Number.isFinite(pppIndex) || pppIndex <= 0) {
+    return 2000;
+  }
+  const baseCostUSD = 2000;
+  const equivalent = baseCostUSD / pppIndex;
+  return Math.max(150, Math.min(8000, Math.round(equivalent)));
+}
 
 export function usePPP() {
   const [countries, setCountries] = useState([]);
@@ -28,135 +21,91 @@ export function usePPP() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    let active = true;
+
     const fetchData = async () => {
       try {
-        console.log('usePPP: Starting data fetch...');
         setIsLoading(true);
-        
-        // Get PPP data
         const countriesWithPPP = await getAllCountries();
-        console.log('usePPP: Received countries:', countriesWithPPP.length);
-        
-        if (countriesWithPPP.length === 0) {
-          throw new Error('No PPP data available');
-        }
+        if (!active) return;
 
-        // Transform to match expected structure
-        const transformedCountries = countriesWithPPP.map(country => ({
-          city: country.originalName, // Using original name for display
+        const transformed = (countriesWithPPP ?? []).map((country) => ({
+          city: country.originalName,
           country: country.originalName,
           normalizedName: country.normalizedName,
           ppp: country.pppIndex,
-          // Add default monthly cost - you should update this based on your actual data
           monthlyCost: estimateMonthlyLivingCost(country.pppIndex),
-          currency: 'USD' // Default currency
+          currency: 'USD',
+          code: country.isoCode ?? null,
         }));
 
-        console.log('usePPP: Transformed countries:', transformedCountries.slice(0, 3));
-        setCountries(transformedCountries);
+        setCountries(transformed);
         setError(null);
-        console.log('usePPP: Data fetch completed successfully');
-      } catch (err) {
-        console.error('Error in usePPP:', err);
-        setError(err);
+      } catch (cause) {
+        if (!active) return;
+        console.error('usePPP: failed to load PPP data', cause);
         setCountries([]);
+        setError(cause instanceof Error ? cause : new Error('Unable to load PPP data'));
       } finally {
-        setIsLoading(false);
+        if (active) setIsLoading(false);
       }
     };
 
     fetchData();
+    return () => {
+      active = false;
+    };
   }, []);
-
-  // Estimate monthly living cost based on PPP index
-  // This is a rough estimation - you should replace with actual data if available
-  const estimateMonthlyLivingCost = (pppIndex) => {
-    // Base cost in USD for a comfortable lifestyle
-    const baseCostUSD = 2000; 
-    // In cheaper countries (high PPP ratio), the USD equivalent is lower
-    // In expensive countries (low PPP ratio), the USD equivalent is higher
-    return Math.round(baseCostUSD / pppIndex * 1); // Simplified estimation
-  };
 
   const cities = useMemo(() => countries, [countries]);
 
   const adjustPrice = useCallback(async (amountUSD, fromCountry, toCountry) => {
     try {
-      console.log(`Adjusting price: ${amountUSD} from ${fromCountry} to ${toCountry}`);
       const result = await getAdjustedPrice(amountUSD, fromCountry, toCountry);
-      
-      if (typeof result === 'number') {
-        console.log(`Adjusted price: ${result.toFixed(2)}`);
-        return result;
-      } else {
-        console.warn(`Price adjustment failed: ${result}`);
-        return amountUSD;
-      }
-    } catch (error) {
-      console.error('Error adjusting price:', error);
+      return typeof result === 'number' ? result : amountUSD;
+    } catch (adjustError) {
+      console.error('usePPP: adjustPrice failed', adjustError);
       return amountUSD;
     }
-  }, []); // No dependencies since it's a pure function
+  }, []);
 
-
-const calculateRunway = useCallback(async (monthlyBudgetUSD, fromCountry, toCountry, monthlyCost) => {
-  try {
-    const result = await calculateBudgetRunway(monthlyBudgetUSD, toCountry);
-    return typeof result === 'number' ? result : 0;
-  } catch (err) {
-    console.error('calculateRunway failed:', err);
-    return 0;
-  }
-}, []);
-
+  const calculateRunway = useCallback(async (monthlyBudgetUSD, _fromCountry, toCountry) => {
+    try {
+      const result = await calculateBudgetRunway(monthlyBudgetUSD, toCountry);
+      return typeof result === 'number' ? result : 0;
+    } catch (cause) {
+      console.error('usePPP: calculateRunway failed', cause);
+      return 0;
+    }
+  }, []);
 
   const getPPPRatio = useCallback(async (fromCountry, toCountry) => {
     try {
       const result = await getPurchasingPowerRatio(fromCountry, toCountry);
       return typeof result === 'number' ? result : null;
-    } catch (error) {
-      console.error('Error getting PPP ratio:', error);
+    } catch (cause) {
+      console.error('usePPP: getPPPRatio failed', cause);
       return null;
     }
   }, []);
 
   const rankedBySavings = useMemo(() => {
-    if (countries.length === 0) {
-      console.log('rankedBySavings: No countries available');
-      return [];
-    }
+    if (countries.length === 0) return [];
+    const baselineCountry = countries.find((entry) => {
+      const lower = entry.normalizedName?.toLowerCase?.() ?? entry.city?.toLowerCase?.() ?? '';
+      return lower.includes('united states') || lower === 'usa';
+    });
+    const baselinePPP = baselineCountry?.ppp ?? 1;
 
-    // Find USA as baseline (try different variations)
-    const baselineCountry = countries.find(c => 
-      c.normalizedName === 'united states' || 
-      c.city.toLowerCase().includes('united states') ||
-      c.city.toLowerCase().includes('usa')
-    );
-    
-    const baselinePPP = baselineCountry?.ppp ?? 1.0;
-    console.log('rankedBySavings: Using baseline PPP:', baselinePPP, 'from country:', baselineCountry?.city);
-
-    const ranked = countries
+    return countries
       .map((country) => {
-        // Calculate savings percentage compared to baseline
-        // Lower PPP means cheaper, so positive savings
-        // Higher PPP means more expensive, so negative savings
         const savings = ((baselinePPP - country.ppp) / baselinePPP) * 100;
-        
         return {
           ...country,
-          savings: parseFloat(savings.toFixed(2))
+          savings: Number.parseFloat(savings.toFixed(2)),
         };
       })
-      .sort((a, b) => b.savings - a.savings); // Sort by highest savings first
-      
-    console.log('rankedBySavings: Top 3 countries by savings:', ranked.slice(0, 3).map(c => ({
-      city: c.city,
-      ppp: c.ppp,
-      savings: c.savings
-    })));
-
-    return ranked;
+      .sort((a, b) => b.savings - a.savings);
   }, [countries]);
 
   return {
@@ -171,6 +120,8 @@ const calculateRunway = useCallback(async (monthlyBudgetUSD, fromCountry, toCoun
     getPPPRatio,
     rankedBySavings,
     isLoading,
-    error
+    error,
   };
 }
+
+export default usePPP;

--- a/src/hooks/usePersonalization.js
+++ b/src/hooks/usePersonalization.js
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { loadPersonalization, markOnboardingComplete, savePersonalization } from '../lib/personalization.js';
+
+const EMPTY_PAYLOAD = {
+  travelGoal: null,
+  travelStyle: null,
+  budgetFocus: null,
+  monthlyBudget: null,
+  curiousCities: [],
+  onboardingComplete: false,
+};
+
+export function usePersonalization(userId) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(Boolean(userId));
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+
+    if (!userId) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return () => {
+        active = false;
+      };
+    }
+
+    setLoading(true);
+    setError(null);
+
+    loadPersonalization(userId)
+      .then((payload) => {
+        if (!active) return;
+        setData(payload ? { ...EMPTY_PAYLOAD, ...payload } : { ...EMPTY_PAYLOAD });
+      })
+      .catch((cause) => {
+        if (!active) return;
+        console.warn('Unable to fetch personalization', cause);
+        setError(cause instanceof Error ? cause : new Error('Unable to load preferences'));
+        setData({ ...EMPTY_PAYLOAD });
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [userId]);
+
+  const save = useCallback(
+    async (partial) => {
+      if (!userId) return null;
+      const next = { ...EMPTY_PAYLOAD, ...(data ?? EMPTY_PAYLOAD), ...partial };
+      try {
+        const persisted = await savePersonalization(userId, next);
+        setData({ ...EMPTY_PAYLOAD, ...persisted });
+        setError(null);
+        return persisted;
+      } catch (persistError) {
+        console.error('Failed to save personalization', persistError);
+        setError(persistError instanceof Error ? persistError : new Error('Unable to save preferences'));
+        const optimistic = { ...EMPTY_PAYLOAD, ...next };
+        setData(optimistic);
+        return optimistic;
+      }
+    },
+    [data, userId]
+  );
+
+  const completeOnboarding = useCallback(
+    async (partial = {}) => {
+      if (!userId) return null;
+      const next = { ...EMPTY_PAYLOAD, ...(data ?? EMPTY_PAYLOAD), ...partial, onboardingComplete: true };
+      try {
+        const persisted = await markOnboardingComplete(userId, next);
+        setData({ ...EMPTY_PAYLOAD, ...persisted, onboardingComplete: true });
+        setError(null);
+        return persisted;
+      } catch (cause) {
+        console.error('Failed to complete onboarding', cause);
+        setError(cause instanceof Error ? cause : new Error('Unable to complete onboarding'));
+        setData(next);
+        return next;
+      }
+    },
+    [data, userId]
+  );
+
+  const value = useMemo(() => {
+    return {
+      ...EMPTY_PAYLOAD,
+      ...(data ?? {}),
+    };
+  }, [data]);
+
+  return {
+    data: value,
+    loading,
+    error,
+    save,
+    completeOnboarding,
+  };
+}
+
+export default usePersonalization;

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,11 @@
   background-color: #eef3fb;
 }
 
+html[data-theme='dark'] {
+  color: #f5f7fa;
+  background-color: #0b1b2b;
+}
+
 body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: #13294b;
@@ -25,6 +30,16 @@ body {
   background-size: cover;
 }
 
+html[data-theme='dark'] body {
+  color: #f5f7fa;
+  background-color: #0b1b2b;
+  background-image:
+    radial-gradient(1200px circle at 12% 10%, rgba(14, 98, 181, 0.3), transparent 65%),
+    radial-gradient(900px circle at 85% 14%, rgba(238, 108, 77, 0.25), transparent 60%),
+    radial-gradient(1100px circle at 25% 85%, rgba(46, 196, 182, 0.22), transparent 62%),
+    linear-gradient(180deg, #0b1b2b 0%, #0f2236 35%, #152a40 100%);
+}
+
 body::before {
   content: '';
   position: fixed;
@@ -38,6 +53,13 @@ body::before {
   z-index: -2;
 }
 
+html[data-theme='dark'] body::before {
+  background-image:
+    radial-gradient(520px circle at 72% 12%, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 45%),
+    repeating-linear-gradient(125deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.04) 2px, transparent 2px, transparent 8px);
+}
+
 body::after {
   content: '';
   position: fixed;
@@ -47,6 +69,12 @@ body::after {
     radial-gradient(320px circle at -5% 32%, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0)),
     radial-gradient(420px circle at 105% 72%, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0));
   z-index: -3;
+}
+
+html[data-theme='dark'] body::after {
+  background-image:
+    radial-gradient(320px circle at -5% 32%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0)),
+    radial-gradient(420px circle at 105% 72%, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
 }
 
 h1,

--- a/src/lib/personalization.js
+++ b/src/lib/personalization.js
@@ -1,0 +1,170 @@
+import { supabase } from './supabase.js';
+
+const LOCAL_STORAGE_KEY = 'ppp_personalization';
+
+function readLocalFallback(userId) {
+  if (!userId || typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(`${LOCAL_STORAGE_KEY}:${userId}`);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (error) {
+    console.warn('Failed to read personalization from localStorage', error);
+    return null;
+  }
+}
+
+function writeLocalFallback(userId, payload) {
+  if (!userId || typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(`${LOCAL_STORAGE_KEY}:${userId}` , JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Failed to persist personalization to localStorage', error);
+  }
+}
+
+export async function loadPersonalization(userId) {
+  if (!userId) return null;
+
+  try {
+    const { data, error } = await supabase
+      .from('user_personalization')
+      .select(
+        `user_id,
+         travel_goal,
+         travel_style,
+         budget_focus,
+         monthly_budget,
+         curious_cities,
+         onboarding_complete,
+         created_at,
+         updated_at`
+      )
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    if (!data) {
+      const local = readLocalFallback(userId);
+      return local ?? null;
+    }
+
+    const parsedCities = (() => {
+      if (!data.curious_cities) return [];
+      if (Array.isArray(data.curious_cities)) return data.curious_cities;
+      if (typeof data.curious_cities === 'string') {
+        try {
+          const parsed = JSON.parse(data.curious_cities);
+          return Array.isArray(parsed) ? parsed : [];
+        } catch (error) {
+          return data.curious_cities
+            .split(',')
+            .map((entry) => entry.trim())
+            .filter(Boolean);
+        }
+      }
+      return [];
+    })();
+
+    const payload = {
+      userId,
+      travelGoal: data.travel_goal ?? null,
+      travelStyle: data.travel_style ?? null,
+      budgetFocus: data.budget_focus ?? null,
+      monthlyBudget: typeof data.monthly_budget === 'number' ? data.monthly_budget : null,
+      curiousCities: parsedCities,
+      onboardingComplete: Boolean(data.onboarding_complete),
+      createdAt: data.created_at ?? null,
+      updatedAt: data.updated_at ?? null,
+    };
+
+    writeLocalFallback(userId, payload);
+    return payload;
+  } catch (error) {
+    console.warn('Failed to load personalization from Supabase, falling back to local cache', error);
+    const fallback = readLocalFallback(userId);
+    return fallback ?? null;
+  }
+}
+
+export async function savePersonalization(userId, payload) {
+  if (!userId) return null;
+
+  const serialised = {
+    travel_goal: payload.travelGoal ?? null,
+    travel_style: payload.travelStyle ?? null,
+    budget_focus: payload.budgetFocus ?? null,
+    monthly_budget:
+      typeof payload.monthlyBudget === 'number' && Number.isFinite(payload.monthlyBudget)
+        ? payload.monthlyBudget
+        : null,
+    curious_cities: Array.isArray(payload.curiousCities)
+      ? payload.curiousCities.filter(Boolean)
+      : [],
+    onboarding_complete: payload.onboardingComplete ?? false,
+  };
+
+  try {
+    const { data, error } = await supabase
+      .from('user_personalization')
+      .upsert(
+        {
+          user_id: userId,
+          ...serialised,
+        },
+        { onConflict: 'user_id' }
+      )
+      .select()
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    const normalised = {
+      userId,
+      travelGoal: data?.travel_goal ?? serialised.travel_goal,
+      travelStyle: data?.travel_style ?? serialised.travel_style,
+      budgetFocus: data?.budget_focus ?? serialised.budget_focus,
+      monthlyBudget: data?.monthly_budget ?? serialised.monthly_budget,
+      curiousCities: (() => {
+        const source = data?.curious_cities ?? serialised.curious_cities;
+        if (Array.isArray(source)) return source;
+        if (typeof source === 'string') {
+          try {
+            const parsed = JSON.parse(source);
+            return Array.isArray(parsed) ? parsed : [];
+          } catch (error) {
+            return source
+              .split(',')
+              .map((entry) => entry.trim())
+              .filter(Boolean);
+          }
+        }
+        return [];
+      })(),
+      onboardingComplete: Boolean(data?.onboarding_complete ?? serialised.onboarding_complete),
+      createdAt: data?.created_at ?? null,
+      updatedAt: data?.updated_at ?? null,
+    };
+
+    writeLocalFallback(userId, normalised);
+    return normalised;
+  } catch (error) {
+    console.error('Failed to persist personalization', error);
+    const cached = { userId, ...payload };
+    writeLocalFallback(userId, cached);
+    return cached;
+  }
+}
+
+export async function markOnboardingComplete(userId, payload = {}) {
+  const result = await savePersonalization(userId, {
+    ...payload,
+    onboardingComplete: true,
+  });
+  return result;
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,8 +1,17 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card.jsx';
 import WorldMap from '../components/score/WorldMap.jsx';
 import CityCard from '../components/score/CityCard.jsx';
-import { supabase } from '../lib/supabase.js';
+import SpendingTrendChart from '../components/dashboard/SpendingTrendChart.jsx';
+import SavingsRunwayPanel from '../components/dashboard/SavingsRunwayPanel.jsx';
+import NotificationsWidget from '../components/dashboard/NotificationsWidget.jsx';
+import { useAccount } from '../hooks/useAccount.js';
+import { useTransactions } from '../hooks/useTransactions.js';
+import { usePPP } from '../hooks/usePPP.js';
+import { useAuth } from '../hooks/useAuth.js';
+import { useUserProfile } from '../hooks/useUserProfile.js';
+import usePersonalization from '../hooks/usePersonalization.js';
+import OnboardingModal from '../components/onboarding/OnboardingModal.jsx';
 
 const COUNTRY_COORDS = {
   bahrain: [26.0667, 50.5577],
@@ -20,155 +29,220 @@ const COUNTRY_COORDS = {
 };
 
 function formatUSD(n) {
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(
-    Number(n) ?? 0
-  );
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(Number(n) ?? 0);
+}
+
+function toTitleCase(s = '') {
+  return s.replace(/\w\S*/g, (t) => t[0].toUpperCase() + t.slice(1).toLowerCase());
+}
+
+function groupTransactionsByWeek(transactions) {
+  if (!Array.isArray(transactions) || transactions.length === 0) return [];
+
+  const weekMap = new Map();
+
+  transactions.forEach((txn) => {
+    const ts = new Date(txn.timestamp ?? txn.date ?? txn.ts ?? Date.now());
+    if (Number.isNaN(ts.getTime())) return;
+    const monday = new Date(ts);
+    const day = monday.getDay();
+    const diff = monday.getDate() - day + (day === 0 ? -6 : 1);
+    monday.setDate(diff);
+    monday.setHours(0, 0, 0, 0);
+    const label = monday.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    const key = monday.toISOString();
+    const amount = Math.abs(Number(txn.amount ?? 0));
+    weekMap.set(key, {
+      key,
+      label,
+      amount: (weekMap.get(key)?.amount ?? 0) + amount,
+      date: monday,
+    });
+  });
+
+  return Array.from(weekMap.values()).sort((a, b) => a.date - b.date);
+}
+
+function buildNotifications({ bestCity, runnerUp, weeklyChange, budgetDelta }) {
+  const notes = [];
+
+  if (bestCity && runnerUp) {
+    const monthlyDiff = Math.max(0, Number(runnerUp.monthlyCost ?? 0) - Number(bestCity.monthlyCost ?? 0));
+    if (monthlyDiff > 0) {
+      notes.push(
+        `Choosing ${bestCity.city} over ${runnerUp.city} saves about $${Math.round(monthlyDiff).toLocaleString()} each month.`
+      );
+    }
+  }
+
+  if (Number.isFinite(weeklyChange)) {
+    const label = weeklyChange > 0 ? 'up' : 'down';
+    notes.push(`Your weekly spending is ${label} ${Math.abs(Math.round(weeklyChange))}% vs. last week.`);
+  }
+
+  if (Number.isFinite(budgetDelta)) {
+    if (budgetDelta > 0) {
+      notes.push(`You’re pacing $${Math.round(budgetDelta).toLocaleString()} under budget — bank the surplus for travel.`);
+    } else if (budgetDelta < 0) {
+      notes.push(`You’re trending $${Math.abs(Math.round(budgetDelta)).toLocaleString()} over budget — adjust for your next trip.`);
+    }
+  }
+
+  return notes;
 }
 
 export function Dashboard() {
-  const [balanceUSD, setBalanceUSD] = useState(0);
-  const [recent, setRecent] = useState([]);
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const { profile } = useUserProfile(userId);
+  const identityFallback = useMemo(() => {
+    if (!user) return '';
+    const md = user.user_metadata ?? {};
+    if (md.displayName && md.displayName.trim()) return md.displayName.trim();
+    if (user.email) return user.email.split('@')[0] ?? '';
+    return '';
+  }, [user]);
 
-  // PPP state (kept from your version)
-  const [pppTop, setPppTop] = useState([]);
-  const [pppMarkers, setPppMarkers] = useState([]);
+  const displayName = profile?.name ?? identityFallback;
 
-  useEffect(() => {
-    let alive = true;
+  const { data: personalization, loading: personalizationLoading, completeOnboarding } = usePersonalization(userId);
 
-    (async () => {
-      // 1. Get logged-in user
-      const { data: userRes, error: userErr } = await supabase.auth.getUser();
-      if (userErr || !userRes?.user) return;
-      const userId = userRes.user.id;
+  const { balanceUSD = 0 } = useAccount();
+  const baseMonthlyBudget = useMemo(() => {
+    if (personalization?.monthlyBudget) return personalization.monthlyBudget;
+    if (profile?.monthlyBudget) return profile.monthlyBudget;
+    return 2500;
+  }, [personalization?.monthlyBudget, profile?.monthlyBudget]);
 
-      // 2. Fetch account balance for this user
-      const { data: acctRows, error: acctErr } = await supabase
-        .from('accounts')
-        .select('balance, currency_code')
-        .eq('user_id', userId)
-        .order('snapshot_ts', { ascending: false })
-        .limit(1);
+  const { transactions, recent, spendingMetrics } = useTransactions({
+    limit: 6,
+    monthlyBudget: baseMonthlyBudget,
+    balanceUSD,
+  });
 
-      if (!acctErr && acctRows?.length > 0) {
-        setBalanceUSD(acctRows[0].balance);
-      }
+  const trendData = useMemo(() => groupTransactionsByWeek(transactions), [transactions]);
 
-      // 3. Fetch recent transactions for this user
-      const { data: txRows, error: txErr } = await supabase
-        .from('transactions')
-        .select('id, merchant, amount, category, ts')
-        .eq('user_id', userId)
-        .order('ts', { ascending: false })
-        .limit(10);
+  const weeklyChange = useMemo(() => {
+    if (trendData.length < 2) return null;
+    const last = trendData[trendData.length - 1].amount;
+    const prev = trendData[trendData.length - 2].amount || 1;
+    if (!prev) return null;
+    const delta = ((last - prev) / prev) * 100;
+    return Number.isFinite(delta) ? delta : null;
+  }, [trendData]);
 
-      if (!txErr && Array.isArray(txRows)) {
-        setRecent(
-          txRows.map((t) => ({
-            id: t.id,
-            merchant: t.merchant,
-            amount: t.amount,
-            category: t.category ?? 'uncategorized',
-            date: t.ts,
-          }))
-        );
-      }
+  const { rankedBySavings } = usePPP();
 
-      // 4. PPP logic (kept intact, only runs once for now)
-      const { data: prof } = await supabase
-        .from('user_profile')
-        .select('current_country_code')
-        .eq('user_id', userId)
-        .maybeSingle();
+  const topDestinations = useMemo(() => {
+    if (!Array.isArray(rankedBySavings)) return [];
+    const focus = personalization?.budgetFocus ?? 'Balanced';
+    return rankedBySavings.slice(0, 6).map((city) => ({
+      ...city,
+      city: toTitleCase(city.city ?? ''),
+      context:
+        focus === 'Rent'
+          ? 'Best rent-to-income ratio'
+          : focus === 'Food'
+            ? 'Strong dining affordability'
+            : focus === 'Leisure'
+              ? 'Leisure spending goes further here'
+              : 'Balanced across categories',
+      runwayMonths:
+        Number.isFinite(city.monthlyCost) && city.monthlyCost > 0
+          ? (baseMonthlyBudget ?? 0) / city.monthlyCost
+          : null,
+    }));
+  }, [rankedBySavings, personalization?.budgetFocus, baseMonthlyBudget]);
 
-      const currentCode = (prof?.current_country_code || 'USA').toUpperCase();
+  const pppMarkers = useMemo(() => {
+    return topDestinations
+      .map((city) => {
+        const coords =
+          COUNTRY_COORDS[city.country?.toLowerCase?.() ?? ''] ?? COUNTRY_COORDS[city.city?.toLowerCase?.() ?? ''];
+        if (!coords) return null;
+        return {
+          city: city.city,
+          coords,
+          ppp: city.ppp ?? 1,
+          context: city.context,
+        };
+      })
+      .filter(Boolean)
+      .slice(0, 5);
+  }, [topDestinations]);
 
-      const { data: rows } = await supabase
-        .from('ppp_country')
-        .select('code, country, 2024_y')
-        .not('2024_y', 'is', null)
-        .limit(300);
+  const pppTop = topDestinations.slice(0, 3);
 
-      if (!rows) return;
+  const notifications = useMemo(
+    () =>
+      buildNotifications({
+        bestCity: topDestinations[0],
+        runnerUp: topDestinations[1],
+        weeklyChange,
+        budgetDelta: spendingMetrics?.budgetDelta ?? null,
+      }),
+    [spendingMetrics?.budgetDelta, topDestinations, weeklyChange]
+  );
 
-      const items = rows
-        .map((r) => ({
-          code: String(r.code || '').toUpperCase(),
-          name: String(r.country || '').toLowerCase(),
-          ppp: Number(r['2024_y']),
-        }))
-        .filter((r) => r.ppp > 0);
+  const heroLabel = displayName ? `${displayName.split(' ')[0]}'s budget` : 'Your budget';
+  const heroSubtitle = baseMonthlyBudget
+    ? `Here’s how $${Number(baseMonthlyBudget).toLocaleString()}/month stretches across the globe.`
+    : 'Let’s see how your money travels.';
 
-      const baseline = items.find((r) => r.code === currentCode);
-      const baselinePPP = baseline?.ppp ?? 100;
+  const showOnboarding = !personalizationLoading && !personalization?.onboardingComplete;
 
-      const enriched = items
-        .map((r) => {
-          const savings = (baselinePPP - r.ppp) / baselinePPP;
-          return {
-            city: toTitleCase(r.name),
-            ppp: r.ppp,
-            savingsPct: Math.max(-1, Math.min(1, savings)),
-            coords: COUNTRY_COORDS[r.name] || null,
-          };
-        })
-        .sort((a, b) => b.savingsPct - a.savingsPct);
-
-      if (alive) {
-        setPppTop(enriched.slice(0, 3));
-        setPppMarkers(
-          enriched.filter((e) => Array.isArray(e.coords)).slice(0, 5).map((e) => ({
-            city: e.city,
-            coords: e.coords,
-            ppp: e.ppp,
-          }))
-        );
-      }
-    })();
-
-    return () => {
-      alive = false;
-    };
-  }, []);
+  const handleOnboardingComplete = async (payload) => {
+    await completeOnboarding(payload);
+  };
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-10 px-6 py-12">
+      <OnboardingModal
+        isOpen={showOnboarding}
+        defaultValues={personalization}
+        onComplete={handleOnboardingComplete}
+        onSkip={() => completeOnboarding({ ...personalization, onboardingComplete: true })}
+        displayName={displayName}
+      />
+
       <div className="grid gap-6 md:grid-cols-3">
-        <Card className="col-span-1 bg-white/85">
+        <Card className="col-span-1 bg-white/90">
           <CardHeader>
-            <CardTitle>Account Balance</CardTitle>
+            <CardTitle>{heroLabel}</CardTitle>
+            <p className="text-xs uppercase tracking-[0.3em] text-teal/60">Dynamic budget profile</p>
           </CardHeader>
           <CardContent>
-            <p className="text-3xl font-poppins font-semibold text-teal">
-              {formatUSD(balanceUSD)}
-            </p>
-            <p className="mt-2 text-sm text-charcoal/70">
-              Capital One demo account synced via Nessie sandbox.
+            <p className="text-3xl font-poppins font-semibold text-teal">{formatUSD(balanceUSD)}</p>
+            <p className="mt-2 text-sm text-charcoal/70">{heroSubtitle}</p>
+            <p className="mt-3 text-xs text-charcoal/50">
+              Dashboard = at a glance: balances, travel power, and PPP-led opportunities.
             </p>
           </CardContent>
         </Card>
 
-        <Card className="col-span-1 md:col-span-2 bg-white/85">
+        <Card className="col-span-1 md:col-span-2 bg-white/90">
           <CardHeader>
             <CardTitle>Recent transactions</CardTitle>
             <p className="text-xs uppercase tracking-[0.3em] text-teal/60">Last 30 days</p>
           </CardHeader>
           <CardContent>
             <ul className="space-y-3">
+              {recent.length === 0 && (
+                <li className="rounded-2xl border border-dashed border-navy/20 px-4 py-6 text-center text-sm text-charcoal/60">
+                  We’ll populate this the moment your Nessie transactions sync.
+                </li>
+              )}
               {recent.map((txn) => (
-                <li
-                  key={txn.id}
-                  className="flex items-center justify-between rounded-2xl bg-offwhite/80 px-4 py-3"
-                >
+                <li key={txn.id} className="flex items-center justify-between rounded-2xl bg-offwhite/80 px-4 py-3">
                   <div>
-                    <p className="font-semibold text-charcoal">{txn.merchant}</p>
+                    <p className="font-semibold text-charcoal">{txn.merchant ?? 'Unknown merchant'}</p>
                     <p className="text-xs text-charcoal/60">
-                      {new Date(txn.date).toLocaleDateString()}
+                      {new Date(txn.timestamp ?? txn.date ?? Date.now()).toLocaleDateString()}
                     </p>
                   </div>
                   <div className="text-right">
                     <p className="font-semibold text-coral">{formatUSD(txn.amount)}</p>
-                    <p className="text-xs text-charcoal/60">{txn.category}</p>
+                    <p className="text-xs text-charcoal/60">{txn.category ?? 'General'}</p>
                   </div>
                 </li>
               ))}
@@ -180,9 +254,27 @@ export function Dashboard() {
       <div className="grid gap-6 lg:grid-cols-2">
         <Card className="bg-white/90">
           <CardHeader>
-            <CardTitle>PPP Score map</CardTitle>
-            <p className="text-xs text-charcoal/60">
-              Leaflet world map placeholder showing PPP hotspots.
+            <CardTitle>Trends & insights</CardTitle>
+            <p className="text-sm text-charcoal/70">
+              {weeklyChange != null
+                ? `Your spending is ${weeklyChange > 0 ? 'up' : 'down'} ${Math.abs(weeklyChange).toFixed(1)}% from last week.`
+                : 'We’ll track spend trends once a second week of data lands.'}
+            </p>
+          </CardHeader>
+          <CardContent>
+            <SpendingTrendChart data={trendData.map(({ label, amount }) => ({ label, amount }))} />
+          </CardContent>
+        </Card>
+
+        <NotificationsWidget items={notifications} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card className="bg-white/90">
+          <CardHeader>
+            <CardTitle>PPP score heatmap</CardTitle>
+            <p className="text-sm text-charcoal/70">
+              Hover the globe to see how your purchasing power compares city by city.
             </p>
           </CardHeader>
           <CardContent>
@@ -191,22 +283,27 @@ export function Dashboard() {
         </Card>
 
         <div className="grid gap-4">
-          {pppTop.map((dest) => (
-            <CityCard
-              key={dest.city}
-              city={dest.city}
-              ppp={dest.ppp}
-              savingsPct={dest.savingsPct}
-            />
-          ))}
+          <SavingsRunwayPanel destinations={topDestinations} stayLengthMonths={6} />
+          <Card className="bg-white/90">
+            <CardHeader>
+              <CardTitle>Top PPP picks</CardTitle>
+              <p className="text-sm text-charcoal/70">GeoBudget = plan travels with personalised budget forecasting.</p>
+            </CardHeader>
+            <CardContent className="grid gap-3">
+              {pppTop.map((dest) => (
+                <CityCard key={dest.city} city={dest.city} ppp={dest.ppp} savingsPct={dest.savings ?? dest.savingsPct} />
+              ))}
+              {pppTop.length === 0 && (
+                <div className="rounded-2xl border border-dashed border-navy/20 px-4 py-6 text-sm text-charcoal/60">
+                  We’re fetching PPP insights — check back in a beat.
+                </div>
+              )}
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>
   );
-}
-
-function toTitleCase(s = '') {
-  return s.replace(/\w\S*/g, (t) => t[0].toUpperCase() + t.slice(1).toLowerCase());
 }
 
 export default Dashboard;

--- a/src/pages/Insights.jsx
+++ b/src/pages/Insights.jsx
@@ -4,48 +4,132 @@ import ComparisonChart from '../components/insights/ComparisonChart.jsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card.jsx';
 import { useTransactions } from '../hooks/useTransactions.js';
 import { usePPP } from '../hooks/usePPP.js';
+import { useAuth } from '../hooks/useAuth.js';
+import { useUserProfile } from '../hooks/useUserProfile.js';
+import usePersonalization from '../hooks/usePersonalization.js';
 
 export function Insights() {
   const { totals } = useTransactions();
   const { rankedBySavings, adjustPrice } = usePPP();
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const { profile } = useUserProfile(userId);
+  const { data: personalization } = usePersonalization(userId);
   const [categories, setCategories] = useState([]);
+  const [chartData, setChartData] = useState([]);
+  const [summary, setSummary] = useState(null);
 
-  // Static values for the base city (e.g. Atlanta)
-  const atlantaSpends = useMemo(() => ({
-    Groceries: totals['Groceries'] ?? 350,
-    Rent: totals['Rent'] ?? 1400,
-    Transport: totals['Transport'] ?? 120
-  }), [totals]);
+  const baselineCountry = useMemo(() => {
+    if (profile?.homeCountry?.name) return profile.homeCountry.name;
+    return 'United States';
+  }, [profile?.homeCountry?.name]);
 
-  // Load adjusted category prices for comparison
+  const atlantaSpends = useMemo(
+    () => ({
+      Groceries: totals['Groceries'] ?? 350,
+      Rent: totals['Rent'] ?? 1400,
+      Transport: totals['Transport'] ?? 120,
+    }),
+    [totals]
+  );
+
   useEffect(() => {
-    const loadAdjustedCategories = async () => {
-      const adjusted = await Promise.all(
+    const targets = personalization?.curiousCities?.length
+      ? personalization.curiousCities
+      : rankedBySavings.slice(0, 3).map((entry) => entry.country ?? entry.city);
+
+    if (!targets || targets.length === 0) return;
+
+    const normalisedTargets = Array.from(new Set(targets))
+      .map((name) => {
+        const match = rankedBySavings.find((entry) => {
+          const lower = name.toLowerCase();
+          const normalized = entry.normalizedName?.toLowerCase?.();
+          return (
+            entry.city?.toLowerCase() === lower ||
+            entry.country?.toLowerCase() === lower ||
+            normalized === lower
+          );
+        });
+        return match?.country ?? match?.city ?? name;
+      })
+      .filter(Boolean)
+      .slice(0, 3);
+
+    async function loadInsights() {
+      const numberFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+
+      const firstCity = normalisedTargets[0];
+      if (!firstCity) return;
+
+      const adjustedCategories = await Promise.all(
         Object.entries(atlantaSpends).map(async ([category, amount]) => {
-          const lisbonAmount = await adjustPrice(amount, 'USA', 'Germany'); // Adjusted country names
-          const delta = typeof lisbonAmount === 'number'
-            ? ((amount - lisbonAmount) / amount) * 100
-            : 0;
+          const adjustedAmount = await adjustPrice(amount, baselineCountry, firstCity);
+          const delta = typeof adjustedAmount === 'number' && amount > 0 ? ((amount - adjustedAmount) / amount) * 100 : 0;
+          let recommendation = '';
+          if (delta > 0) {
+            recommendation = category === 'Groceries'
+              ? 'Stock up on local markets — your food budget goes further here.'
+              : category === 'Rent'
+                ? 'Consider upgrading your stay or banking the rent savings.'
+                : 'Redirect the savings into weekend adventures.';
+          } else if (delta < 0) {
+            recommendation = category === 'Groceries'
+              ? 'Cook at home a few nights to offset pricier groceries.'
+              : category === 'Rent'
+                ? 'Choose a co-living or suburban neighbourhood to balance the rent jump.'
+                : 'Lean on biking or public transit passes to stay on budget.';
+          }
 
           return {
             title: category,
-            description: `Atlanta ${new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount)} vs. Berlin ${new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(lisbonAmount)}`,
-            delta: parseFloat(delta.toFixed(1))
+            description: `${baselineCountry} ${numberFormatter.format(amount)} vs. ${firstCity} ${numberFormatter.format(
+              adjustedAmount ?? amount
+            )}`,
+            delta: parseFloat(delta.toFixed(1)),
+            recommendation,
           };
         })
       );
-      setCategories(adjusted);
-    };
 
-    loadAdjustedCategories();
-  }, [adjustPrice, atlantaSpends]);
+      setCategories(adjustedCategories);
 
-  const chartData = useMemo(() => {
-    return rankedBySavings.slice(0, 5).map((city) => ({
-      city: city.city,
-      value: Number(((1 - city.ppp) * 100).toFixed(1))
-    }));
-  }, [rankedBySavings]);
+      const chartRows = await Promise.all(
+        normalisedTargets.map(async (cityName) => {
+          const rent = await adjustPrice(atlantaSpends.Rent, baselineCountry, cityName);
+          const groceries = await adjustPrice(atlantaSpends.Groceries, baselineCountry, cityName);
+          const transport = await adjustPrice(atlantaSpends.Transport, baselineCountry, cityName);
+          const total = [rent, groceries, transport].reduce(
+            (sum, value) => sum + (Number.isFinite(value) ? value : 0),
+            0
+          );
+          return {
+            city: cityName,
+            Rent: total > 0 ? (rent ?? 0) / total : 0,
+            Groceries: total > 0 ? (groceries ?? 0) / total : 0,
+            Transport: total > 0 ? (transport ?? 0) / total : 0,
+          };
+        })
+      );
+
+      setChartData(chartRows);
+
+      const [headlineCategory, comparisonCategory] = adjustedCategories;
+      if (headlineCategory && comparisonCategory) {
+        const headline = headlineCategory.delta < 0
+          ? `You’d spend ${Math.abs(headlineCategory.delta).toFixed(0)}% more on ${headlineCategory.title.toLowerCase()} in ${firstCity}.`
+          : `You’d save ${headlineCategory.delta.toFixed(0)}% on ${headlineCategory.title.toLowerCase()} in ${firstCity}.`;
+        const contrast = comparisonCategory.delta < 0
+          ? `Meanwhile, ${comparisonCategory.title.toLowerCase()} runs ${Math.abs(comparisonCategory.delta).toFixed(0)}% hotter.`
+          : `${comparisonCategory.title} drops ${comparisonCategory.delta.toFixed(0)}%.`;
+        setSummary(`${headline} ${contrast}`);
+      } else {
+        setSummary(null);
+      }
+    }
+
+    loadInsights();
+  }, [adjustPrice, atlantaSpends, baselineCountry, personalization?.curiousCities, rankedBySavings]);
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-10 px-6 py-12">
@@ -55,6 +139,8 @@ export function Insights() {
           <p className="text-sm text-charcoal/70">
             Compare your spending categories with global PPP adjustments to see how far your dollars stretch.
           </p>
+          {summary && <p className="mt-2 text-sm font-semibold text-teal">{summary}</p>}
+          <p className="mt-1 text-xs text-charcoal/60">Smart-Spend = see exactly where your money goes globally.</p>
         </CardHeader>
         <CardContent>
           <div className="grid gap-6 md:grid-cols-3">
@@ -67,7 +153,7 @@ export function Insights() {
       <Card className="bg-white/90">
         <CardHeader>
           <CardTitle>PPP comparison</CardTitle>
-          <p className="text-sm text-charcoal/70">Your $100 in Atlanta ≈ amount shown in each city after PPP adjustments.</p>
+          <p className="text-sm text-charcoal/70">Your $100 baseline redistributes across rent, groceries, and transport in each city.</p>
         </CardHeader>
         <CardContent>
           <ComparisonChart data={chartData} />

--- a/src/pages/Share.jsx
+++ b/src/pages/Share.jsx
@@ -2,19 +2,44 @@ import { useMemo, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card.jsx';
 import ShareSummary from '../components/share/ShareSummary.jsx';
 import ExportActions from '../components/share/ExportActions.jsx';
+import SocialButtons from '../components/share/SocialButtons.jsx';
 import { useAccount } from '../hooks/useAccount.js';
 import { usePPP } from '../hooks/usePPP.js';
+import { useAuth } from '../hooks/useAuth.js';
+import { useUserProfile } from '../hooks/useUserProfile.js';
+import usePersonalization from '../hooks/usePersonalization.js';
 
 export function Share() {
   const { balanceUSD } = useAccount();
   const { rankedBySavings } = usePPP();
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const { profile } = useUserProfile(userId);
+  const { data: personalization } = usePersonalization(userId);
   const summaryRef = useRef(null);
 
-  const bestCity = useMemo(() => rankedBySavings[0] ?? { city: 'Lisbon', savings: 28 }, [rankedBySavings]);
+  const baselineCountry = useMemo(() => {
+    if (profile?.homeCountry?.name) return profile.homeCountry.name;
+    return 'PPP Passport';
+  }, [profile?.homeCountry?.name]);
+
+  const bestCity = useMemo(() => {
+    if (!rankedBySavings.length) return { city: 'Lisbon', savings: 28, runwayLabel: '2.4 years' };
+    const [top] = rankedBySavings;
+    const runwayLabel = top.monthlyCost && personalization?.monthlyBudget
+      ? `${(personalization.monthlyBudget / top.monthlyCost).toFixed(1)} months`
+      : 'Ready when you are';
+    return {
+      ...top,
+      runwayLabel,
+      countryCode: top.countryCode ?? top.code ?? '',
+    };
+  }, [personalization?.monthlyBudget, rankedBySavings]);
+
   const score = useMemo(() => {
     if (!rankedBySavings.length) return 72;
     const base = 80;
-    const adjustment = Math.max(-10, Math.min(10, bestCity.savings / 5));
+    const adjustment = Math.max(-10, Math.min(10, (bestCity.savings ?? 0) / 5));
     return Math.round(base + adjustment);
   }, [bestCity.savings, rankedBySavings.length]);
 
@@ -24,12 +49,20 @@ export function Share() {
         <CardHeader>
           <CardTitle>Share your PPP story</CardTitle>
           <p className="text-sm text-charcoal/70">
-            Export a polished PPP summary to show friends or clients how your dollars stretch across destinations.
+            Export a polished travel card or send a quick share so friends can see where your dollars stretch the furthest.
           </p>
+          <p className="mt-1 text-xs text-charcoal/60">Share = turn insights into stories to share with others.</p>
         </CardHeader>
         <CardContent className="flex flex-col items-center gap-8">
-          <ShareSummary ref={summaryRef} bestCity={bestCity} score={score} balance={balanceUSD} />
+          <ShareSummary
+            ref={summaryRef}
+            bestCity={bestCity}
+            score={score}
+            balance={balanceUSD}
+            baselineCountry={baselineCountry}
+          />
           <ExportActions targetRef={summaryRef} />
+          <SocialButtons summaryRef={summaryRef} />
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- introduce a personalized onboarding flow that captures travel goals and stores them through the new personalization hook and Supabase helper
- upgrade the dashboard with trend charts, PPP runway insights, contextual notifications, and dark-mode toggle support
- enhance GeoBudget, Smart-Spend, and Share experiences with user-curated filters, actionable recommendations, and a polished shareable travel report

## Testing
- pnpm run build *(fails: pnpm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8465497b4832d946e9de42653a9ba