### PR TITLE
Reduce auth session loading delay

### DIFF
--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -47,12 +47,12 @@ export function NavBar() {
   }, [user]);
 
   async function handleSignOut() {
+    setIsSigningOut(true);
     try {
-      setIsSigningOut(true);
       await signOut();
-      navigate('/', { replace: true });
     } finally {
       setIsSigningOut(false);
+      navigate('/', { replace: true });
     }
   }
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { supabase } from '../lib/supabase.js';
+import { supabase, supabaseAuthStorageKey } from '../lib/supabase.js';
 import {
   ensureNessieCustomer,
   loadAccountsFromSupabase,
@@ -23,18 +23,25 @@ const initialNessieState = {
   transactions: []
 };
 
+const SESSION_VALIDITY_GRACE_MS = 30 * 1000;
+
 const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
-  const [session, setSession] = useState(null);
-  const [user, setUser] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const initialAuthSnapshot = useMemo(() => getInitialAuthSnapshot(), []);
+  const [session, setSession] = useState(initialAuthSnapshot.session);
+  const [user, setUser] = useState(initialAuthSnapshot.user);
+  const [isLoading, setIsLoading] = useState(!initialAuthSnapshot.hydrated);
   const [nessieState, setNessieState] = useState(initialNessieState);
   const [isSyncingNessie, setIsSyncingNessie] = useState(false);
   const [authError, setAuthError] = useState(null);
 
   useEffect(() => {
     const initialise = async () => {
+      if (!initialAuthSnapshot.hydrated) {
+        setIsLoading(true);
+      }
+
       const { data, error } = await supabase.auth.getSession();
       if (error) {
         setAuthError(error);
@@ -62,6 +69,8 @@ export function AuthProvider({ children }) {
         await syncNessie(nextSession.user);
       } else {
         setNessieState(initialNessieState);
+        setIsLoading(false);
+        clearCachedSupabaseSession();
       }
     });
 
@@ -139,10 +148,17 @@ export function AuthProvider({ children }) {
   );
 
   const signOut = useCallback(async () => {
-    await supabase.auth.signOut();
-    setSession(null);
-    setUser(null);
-    setNessieState(initialNessieState);
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error('Supabase sign-out failed, clearing local state', error);
+    } finally {
+      setSession(null);
+      setUser(null);
+      setNessieState(initialNessieState);
+      setIsLoading(false);
+      clearCachedSupabaseSession();
+    }
   }, []);
 
   const value = useMemo(
@@ -236,4 +252,75 @@ async function ensureUserIdentity(authUser) {
   }
 
   return authUser;
+}
+
+function getInitialAuthSnapshot() {
+  if (typeof window === 'undefined') {
+    return { session: null, user: null, hydrated: false };
+  }
+
+  if (!supabaseAuthStorageKey) {
+    return { session: null, user: null, hydrated: true };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(supabaseAuthStorageKey);
+    if (!raw) {
+      return { session: null, user: null, hydrated: true };
+    }
+
+    const parsed = JSON.parse(raw);
+    const storedSession = parsed?.currentSession ?? parsed?.session ?? null;
+    const storedUser =
+      parsed?.currentUser ?? parsed?.user ?? storedSession?.user ?? null;
+
+    if (!isSessionValid(storedSession)) {
+      clearCachedSupabaseSession();
+      return { session: null, user: null, hydrated: true };
+    }
+
+    return {
+      session: storedSession,
+      user: storedUser ?? null,
+      hydrated: true
+    };
+  } catch (error) {
+    console.warn('Failed to read cached Supabase session', error);
+    return { session: null, user: null, hydrated: true };
+  }
+}
+
+function isSessionValid(session) {
+  if (!session) {
+    return false;
+  }
+
+  const rawExpiry = session.expires_at ?? session.expiry_time ?? null;
+  if (!rawExpiry) {
+    return true;
+  }
+
+  const expirySeconds = typeof rawExpiry === 'number' ? rawExpiry : Number(rawExpiry);
+  if (Number.isNaN(expirySeconds)) {
+    return true;
+  }
+
+  const expiryWithGrace = expirySeconds * 1000 - SESSION_VALIDITY_GRACE_MS;
+  return expiryWithGrace > Date.now();
+}
+
+function clearCachedSupabaseSession() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (!supabaseAuthStorageKey) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(supabaseAuthStorageKey);
+  } catch (error) {
+    console.warn('Failed to clear cached Supabase session', error);
+  }
 }

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -11,6 +11,22 @@ if (!supabaseAnonKey) {
   throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable');
 }
 
+function deriveSupabaseAuthStorageKey(url) {
+  try {
+    const { hostname } = new URL(url);
+    const [projectRef] = hostname.split('.');
+    if (!projectRef) {
+      return null;
+    }
+    return `sb-${projectRef}-auth-token`;
+  } catch (error) {
+    console.warn('Failed to derive Supabase auth storage key', error);
+    return null;
+  }
+}
+
+export const supabaseAuthStorageKey = deriveSupabaseAuthStorageKey(supabaseUrl);
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
     autoRefreshToken: true,
@@ -18,3 +34,5 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     detectSessionInUrl: true
   }
 });
+
+export default supabase;


### PR DESCRIPTION
## Summary
- hydrate the auth context from the cached Supabase session so protected routes render without a long loader
- clear stale Supabase session data and handle sign-out failures to guarantee users end up signed out
- always navigate back to the landing page after signing out from the navigation bar

## Testing
- pnpm run build *(fails: Rollup failed to resolve import "html-to-image" – existing project issue)*

------
https://chatgpt.com/codex/tasks/task_e_68d8940d82a0832dbb9ee6b8ed2be08a