### PR TITLE
Improve profile and finance data refresh flow

### DIFF
--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -203,8 +203,11 @@ function mapProfile(row) {
       ? row.home_city_code.trim().toUpperCase()
       : "";
 
+  const name = typeof row.name === "string" ? row.name : "";
+
   return {
-    name: typeof row.name === "string" ? row.name : "",
+    name,
+    displayName: name,
     monthlyBudget,
     streetAddress,
     streetAddressRaw,
@@ -225,7 +228,7 @@ function mapProfile(row) {
 // --------------------
 export function useUserProfile(userId) {
   const [profile, setProfile] = useState(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(Boolean(userId));
   const [error, setError] = useState(null);
 
   const loadProfile = useCallback(async () => {


### PR DESCRIPTION
## Summary
- normalise profile addresses as formatted strings, seed the settings form optimistically, and fix loading/disable flags while refreshing after saves
- expose a camelCase `displayName` from `useUserProfile` and initialise loading state when a profile is requested
- drive dashboard balances and trends from the shared account/transaction hooks so figures update immediately after refreshes

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8b1e7bbc8832d96cfbb9b308635b2