### PR TITLE
Fix sign-out flow and onboarding experience

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
 import NavBar from './components/layout/NavBar.jsx';
 import Footer from './components/layout/Footer.jsx';
@@ -16,6 +17,14 @@ import DemoAdminStatus from './pages/DemoAdminStatus.jsx';
 
 function App() {
   const location = useLocation();
+  const { refreshSession } = useAuth();
+
+  useEffect(() => {
+    if (!refreshSession) return;
+    refreshSession().catch((error) => {
+      console.warn('Failed to refresh auth session on navigation', error);
+    });
+  }, [location.key, refreshSession]);
 
   return (
     <div className="relative min-h-screen overflow-hidden text-charcoal">

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -48,7 +48,7 @@ export function NavBar() {
     try {
       setIsSigningOut(true);
       await signOut();
-      navigate('/', { replace: true });
+      navigate('/login', { replace: true });
     } finally {
       setIsSigningOut(false);
     }


### PR DESCRIPTION
## Summary
- clear Supabase tokens on sign-out, expose a refresh helper, and harden AuthProvider state updates
- refresh the authenticated session when routes change and redirect signed-out users to the login screen
- automatically surface the personalization quiz for new accounts and persist completion/skip actions

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d8bb7d3254832d8193fdc538938c7a