### PR TITLE
Allow dashboard to render during Nessie sync

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -117,12 +117,6 @@ export default function Dashboard() {
       return;
     }
 
-    if (isSyncingNessie) {
-      return () => {
-        alive = false;
-      };
-    }
-
     setAccountsLoading(true);
 
     (async () => {
@@ -182,8 +176,8 @@ export default function Dashboard() {
             setBalanceUSD(0);
             setSelectedType(null);
           }
-          setAccountsLoading(false);
         }
+        setAccountsLoading(false);
         return;
       }
 
@@ -233,12 +227,11 @@ export default function Dashboard() {
         console.warn('Failed to hydrate accounts for dashboard', error);
       })
       .finally(() => {
-        if (alive) {
-          setAccountsLoading(false);
-        }
+        setAccountsLoading(false);
       });
 
     return () => {
+      setAccountsLoading(false);
       alive = false;
     };
   }, [nessie?.accounts, userId, isSyncingNessie]);
@@ -255,12 +248,6 @@ export default function Dashboard() {
     if (!userId || !selectedId) {
       setTransactionsLoading(false);
       return;
-    }
-
-    if (isSyncingNessie) {
-      return () => {
-        alive = false;
-      };
     }
 
     setTransactionsLoading(true);
@@ -404,12 +391,11 @@ export default function Dashboard() {
         console.warn('Failed to hydrate transactions for dashboard', error);
       })
       .finally(() => {
-        if (alive) {
-          setTransactionsLoading(false);
-        }
+        setTransactionsLoading(false);
       });
 
     return () => {
+      setTransactionsLoading(false);
       alive = false;
     };
   }, [
@@ -524,11 +510,12 @@ export default function Dashboard() {
     ? `Here’s how $${Number(baseMonthlyBudget).toLocaleString()}/month stretches across the globe.`
     : 'Let’s see how your money travels.';
 
+  const hasCachedAccounts =
+    accounts.length > 0 || (Array.isArray(nessie?.accounts) && nessie.accounts.length > 0);
   const showDashboardLoader =
     authLoading ||
-    (userId &&
-      (isSyncingNessie || accountsLoading || (transactionsLoading && recent.length === 0)) &&
-      accounts.length === 0);
+    (userId && !hasCachedAccounts && (accountsLoading || isSyncingNessie || transactionsLoading));
+  const showSyncingIndicator = Boolean(userId && isSyncingNessie && hasCachedAccounts);
 
   if (showDashboardLoader) {
     return <DashboardLoader message="Loading your latest balances" />;
@@ -537,6 +524,11 @@ export default function Dashboard() {
   // Render
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8">
+      {showSyncingIndicator && (
+        <div className="flex justify-end text-xs text-teal/70">
+          <InlineLoader label="Syncing latest balances" />
+        </div>
+      )}
       {/* Hero / Accounts */}
       <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
         <Card className="col-span-1 bg-white/90">


### PR DESCRIPTION
## Summary
- allow the dashboard account and transaction loaders to run during Nessie sync and always clear their loading flags
- update the loader gating to use cached data and surface an inline syncing indicator instead of blocking the page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8c4e66a78832d9a1d10b9b24d7508