### PR TITLE
Update GeoBudget planner filters and card styling

### DIFF
--- a/src/components/planner/RunwayCard.jsx
+++ b/src/components/planner/RunwayCard.jsx
@@ -3,11 +3,11 @@ import { Card } from '../ui/Card.jsx';
 import Progress from '../ui/Progress.jsx';
 import capitals from './capitals.js';
 
-const CATEGORY_META = {
-  rent: { label: 'Rent', icon: '🏠' },
-  food: { label: 'Food', icon: '🍔' },
-  transport: { label: 'Transport', icon: '🚇' },
-  leisure: { label: 'Leisure', icon: '🎉' },
+const CATEGORY_LABELS = {
+  rent: 'Rent',
+  food: 'Food',
+  transport: 'Transport',
+  leisure: 'Leisure',
 };
 
 function formatRunway(runway) {
@@ -28,11 +28,11 @@ function formatCurrency(amount, currency) {
 }
 
 function capitalizeFirstLetter(str) {
-  if (!str) return "";
+  if (!str) return '';
   return str
-    .split(" ")
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join(" ");
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
 }
 
 export function RunwayCard({
@@ -43,7 +43,6 @@ export function RunwayCard({
   currency = 'USD',
   stayDurationMonths = 6,
   breakdown = {},
-  lifestyleTags = [],
   continent,
   safetyScore,
   funScore,
@@ -61,7 +60,6 @@ export function RunwayCard({
     : `Estimated cost of living in ${countryName}`;
 
   const sortedSegments = segments.slice().sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0));
-  const tagList = lifestyleTags.slice(0, 3);
 
   return (
     <Card
@@ -83,20 +81,19 @@ export function RunwayCard({
           </div>
           <div className="flex flex-wrap gap-2 text-[11px] font-semibold uppercase tracking-wide text-charcoal/60">
             {continent && <span className="rounded-full bg-turquoise/20 px-2 py-1 text-teal">{continent}</span>}
-            {tagList.map((tag) => (
-              <span key={tag} className="rounded-full bg-white px-2 py-1 text-teal/80 ring-1 ring-teal/20">
-                #{tag}
-              </span>
-            ))}
           </div>
         </div>
         <div className="flex flex-col items-end gap-1 text-right">
           <span className="rounded-full bg-turquoise/20 px-3 py-1 text-xs font-semibold text-teal">
             {formatRunway(runway)}
           </span>
-          <div className="flex items-center gap-2 text-[11px] font-semibold text-charcoal/60">
-            <span className="rounded-full bg-white px-2 py-1 shadow-sm">🛡️ {safetyScore ?? 0}</span>
-            <span className="rounded-full bg-white px-2 py-1 shadow-sm">🎈 {funScore ?? 0}</span>
+          <div className="flex flex-col items-end text-[11px] font-semibold text-charcoal/60">
+            <span className="rounded-full bg-white px-2 py-1 shadow-sm">
+              Safety score: {safetyScore ?? 0}
+            </span>
+            <span className="rounded-full bg-white px-2 py-1 shadow-sm">
+              Leisure score: {funScore ?? 0}
+            </span>
           </div>
         </div>
       </div>
@@ -115,21 +112,17 @@ export function RunwayCard({
             <ul className="grid gap-2 sm:grid-cols-2">
               {sortedSegments.map(([label, value]) => {
                 const key = String(label).toLowerCase();
-                const meta = CATEGORY_META[key] ?? {
-                  label,
-                  icon: '•',
-                };
+                const displayLabel = CATEGORY_LABELS[key] ?? label;
 
                 return (
                   <li
                     key={label}
-                    className="flex items-center justify-between rounded-xl bg-turquoise/15 px-3 py-2 font-semibold text-charcoal"
+                    className="rounded-xl bg-turquoise/15 px-3 py-2 text-left text-sm text-charcoal/80"
                   >
-                    <span className="flex items-center gap-2">
-                      <span className="text-base">{meta.icon}</span>
-                      {meta.label}
-                    </span>
-                    <span className="text-teal">{Math.round((value ?? 0) * 100)}%</span>
+                    <p className="font-semibold text-teal">{displayLabel}</p>
+                    <p className="text-xs text-charcoal/60">
+                      Approximate share of monthly budget: {Math.round((value ?? 0) * 100)}%
+                    </p>
                   </li>
                 );
               })}


### PR DESCRIPTION
## Summary
- remove the promotional headline banner from the GeoBudget planner and keep the focus on the card grid
- streamline filters to support continent selection plus neutral sort options and improve city name capitalization
- simplify runway cards by dropping lifestyle tags and emoji scores while keeping textual budget breakdowns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8ce16f9f0832da2116b683a8e88e3