### PR TITLE
Ensure page transitions remount and scroll to top

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,8 @@ function App() {
     });
   }, [location.key, refreshSession]);
 
+  const transitionKey = `${location.key ?? 'root'}:${location.pathname}${location.search}${location.hash}`;
+
   return (
     <div className="relative min-h-screen overflow-hidden text-charcoal">
       <div className="pointer-events-none absolute inset-0 -z-10">
@@ -35,8 +37,8 @@ function App() {
         <div className="absolute inset-x-0 bottom-[-20%] h-[18rem] bg-gradient-to-t from-navy/15 via-transparent to-transparent blur-3xl" />
       </div>
       <NavBar />
-      <RouteTransitions key={location.pathname}>
-        <Routes location={location}>
+      <RouteTransitions transitionKey={transitionKey}>
+        <Routes location={location} key={transitionKey}>
           <Route path="/" element={<HomeRoute />} />
           <Route
             path="/login"

--- a/src/components/layout/RouteTransitions.jsx
+++ b/src/components/layout/RouteTransitions.jsx
@@ -1,5 +1,5 @@
+import { useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useLocation } from 'react-router-dom';
 
 const variants = {
   initial: { opacity: 0, y: 24 },
@@ -7,13 +7,18 @@ const variants = {
   exit: { opacity: 0, y: -24 }
 };
 
-export function RouteTransitions({ children }) {
-  const location = useLocation();
+export function RouteTransitions({ children, transitionKey }) {
+  const effectiveKey = transitionKey ?? 'route-transition';
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [effectiveKey]);
 
   return (
     <AnimatePresence mode="wait">
       <motion.main
-        key={location.pathname}
+        key={effectiveKey}
         role="main"
         variants={variants}
         initial="initial"


### PR DESCRIPTION
## Summary
- derive a stable transition key from the full URL and propagate it to the animated route container
- force the routed content tree to remount on navigation so fresh data loads with each page change
- scroll to the top smoothly during transitions to keep page swaps feeling seamless

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8da38b6c8832d8a4bb32033a11f92