### PR TITLE
Show personalization form immediately after signup

### DIFF
--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -96,9 +96,6 @@ export function SignupPage() {
     if (data.user) {
       await persistUserIdentity(data.user, displayName.trim());
       setCreatedUser(data.user);
-    }
-
-    if (data.session && data.user) {
       setShowOnboarding(true);
       setIsSubmitting(false);
       return;


### PR DESCRIPTION
## Summary
- open the onboarding personalization modal as soon as a new user account is created
- keep the existing onboarding completion flow intact after the form is filled or skipped

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d904eb2aac832db8720eaaec7fef73