### PR TITLE
Optimize Nessie data sync performance

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import { supabase } from '../lib/supabase.js';
 import {
+  clearCachedNessieCustomer,
   ensureNessieCustomer,
   loadAccountsFromSupabase,
   loadTransactionsFromSupabase,
@@ -265,6 +266,7 @@ export function AuthProvider({ children }) {
     setNessieState(initialNessieState);
     activeSessionRef.current = null;
     clearCachedSession();
+    clearCachedNessieCustomer();
     try {
       const { error } = await supabase.auth.signOut({ scope: 'global' });
       if (error) {

--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -9,7 +9,7 @@ import { useAuth } from './useAuth.js';
 
 const MS_IN_DAY = 1000 * 60 * 60 * 24;
 
-export function useTransactions({ limit = 5, monthlyBudget, balanceUSD } = {}) {
+export function useTransactions({ limit = 5, monthlyBudget, balanceUSD, customerId: providedCustomerId } = {}) {
   const { user } = useAuth();
   const userId = user?.id ?? null;
 
@@ -17,6 +17,22 @@ export function useTransactions({ limit = 5, monthlyBudget, balanceUSD } = {}) {
   const [isLoading, setIsLoading] = useState(Boolean(userId));
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState(null);
+  const isCustomerIdControlled = providedCustomerId !== undefined;
+  const [resolvedCustomerId, setResolvedCustomerId] = useState(
+    (isCustomerIdControlled ? providedCustomerId : user?.user_metadata?.nessieCustomerId) ?? null
+  );
+
+  useEffect(() => {
+    if (isCustomerIdControlled) {
+      setResolvedCustomerId(providedCustomerId ?? null);
+    }
+  }, [isCustomerIdControlled, providedCustomerId]);
+
+  useEffect(() => {
+    if (!isCustomerIdControlled) {
+      setResolvedCustomerId(user?.user_metadata?.nessieCustomerId ?? null);
+    }
+  }, [isCustomerIdControlled, user?.id, user?.user_metadata?.nessieCustomerId]);
 
   useEffect(() => {
     let active = true;
@@ -51,14 +67,22 @@ export function useTransactions({ limit = 5, monthlyBudget, balanceUSD } = {}) {
     };
   }, [userId]);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async ({ forceRefresh = false } = {}) => {
     if (!userId || !user) {
       return [];
     }
 
     setIsRefreshing(true);
     try {
-      const { customerId } = await ensureNessieCustomer(user);
+      let customerId = resolvedCustomerId ?? null;
+      if (!customerId || forceRefresh) {
+        const ensured = await ensureNessieCustomer(user, { forceRefresh });
+        customerId = ensured.customerId;
+        if (!isCustomerIdControlled) {
+          setResolvedCustomerId(customerId);
+        }
+      }
+
       const rows = await syncTransactionsFromNessie({ userId, customerId });
       const mapped = rows.map((row) => mapTransactionRow(row)).filter(Boolean);
       setTransactions(mapped);
@@ -82,7 +106,7 @@ export function useTransactions({ limit = 5, monthlyBudget, balanceUSD } = {}) {
       setIsRefreshing(false);
       setIsLoading(false);
     }
-  }, [user, userId]);
+  }, [isCustomerIdControlled, resolvedCustomerId, user, userId]);
 
   const orderedTransactions = useMemo(() => {
     return [...transactions].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
@@ -153,6 +177,7 @@ export function useTransactions({ limit = 5, monthlyBudget, balanceUSD } = {}) {
     isLoading,
     isRefreshing,
     error,
-    refresh
+    refresh,
+    customerId: resolvedCustomerId
   };
 }

--- a/src/lib/nessie.js
+++ b/src/lib/nessie.js
@@ -3,6 +3,37 @@ import { supabase } from './supabase.js';
 const NESSIE_BASE_URL = import.meta.env.VITE_NESSIE_BASE_URL ?? 'https://api.nessieisreal.com';
 const NESSIE_API_KEY = import.meta.env.VITE_NESSIE_API_KEY;
 
+const ENSURE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const ensureCache = new Map();
+
+function readEnsureCache(userId) {
+  if (!userId) return null;
+  const cached = ensureCache.get(userId);
+  if (!cached) return null;
+  if (cached.expiresAt <= Date.now()) {
+    ensureCache.delete(userId);
+    return null;
+  }
+  return cached;
+}
+
+function writeEnsureCache(userId, payload) {
+  if (!userId || !payload) return;
+  ensureCache.set(userId, {
+    customerId: payload.customerId ?? null,
+    user: payload.user ?? null,
+    expiresAt: Date.now() + ENSURE_CACHE_TTL_MS
+  });
+}
+
+export function clearCachedNessieCustomer(userId) {
+  if (userId) {
+    ensureCache.delete(userId);
+  } else {
+    ensureCache.clear();
+  }
+}
+
 function buildUrl(path, query = {}) {
   if (!path.startsWith('/')) {
     throw new Error('Nessie API paths must start with a leading slash');
@@ -137,9 +168,17 @@ export async function persistNessieCustomerId({ userId, customerId, metadata = {
   return userData?.user ?? null;
 }
 
-export async function ensureNessieCustomer(user, { persist = true } = {}) {
+export async function ensureNessieCustomer(user, { persist = true, forceRefresh = false } = {}) {
   if (!user?.id) {
     throw new Error('ensureNessieCustomer requires an authenticated Supabase user');
+  }
+
+  const cachedEntry = !forceRefresh ? readEnsureCache(user.id) : null;
+  if (cachedEntry?.customerId) {
+    return {
+      customerId: cachedEntry.customerId,
+      user: cachedEntry.user ?? user
+    };
   }
 
   const metadataId = user.user_metadata?.nessieCustomerId ?? null;
@@ -154,7 +193,7 @@ export async function ensureNessieCustomer(user, { persist = true } = {}) {
   }
 
   let existingCustomer = null;
-  if (storedId) {
+  if (storedId && (forceRefresh || !metadataId || !cachedEntry)) {
     try {
       existingCustomer = await fetchCustomer(storedId);
     } catch (error) {
@@ -185,6 +224,8 @@ export async function ensureNessieCustomer(user, { persist = true } = {}) {
       console.error('Failed to persist Nessie customer id to Supabase', error);
     }
   }
+
+  writeEnsureCache(user.id, { customerId, user: updatedUser ?? user });
 
   return { customerId, user: updatedUser };
 }

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -91,6 +91,8 @@ export default function Settings() {
 
   const {
     accounts,
+    balanceUSD,
+    customerId,
     isRefreshing: accountsRefreshing,
     error: accountsError,
     refresh: refreshAccounts,
@@ -100,7 +102,12 @@ export default function Settings() {
     typeof profile?.monthlyBudget === 'number' ? profile.monthlyBudget : null;
 
   const { isRefreshing: transactionsRefreshing, refresh: refreshTransactions } =
-    useTransactions({ limit: 5, monthlyBudget: monthlyBudgetNumber, balanceUSD: 0 });
+    useTransactions({
+      limit: 5,
+      monthlyBudget: monthlyBudgetNumber,
+      balanceUSD,
+      customerId,
+    });
 
   // form state (persisted as a local draft and overwritten by saved profile)
   const [displayName, setDisplayName] = useState('');


### PR DESCRIPTION
## Summary
- cache ensured Nessie customer IDs to avoid repeated verification requests
- reuse the ensured customer ID across account and transaction refresh hooks and settings
- clear cached customer data on sign-out and surface real balances for downstream metrics

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d91cdd2e38832dbedb8efd858dd290